### PR TITLE
Fixed small bug in testNavigateToIndirectSubfolder()

### DIFF
--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/BoxTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/BoxTest.java
@@ -265,7 +265,7 @@ public class BoxTest extends AndroidTestCase {
 
         nav = volume.navigate();
         try {
-            nav.delete(subfolder);
+            nav.navigate(subfolder);
         } catch (QblStorageNotFound e) {
             return;
         }


### PR DESCRIPTION
Fixup to #86 

Replaced navigation.delete() with intended navigation.navigate(), although currently
navigation.navigate() is called by navigation.delete() and thus the test works.