### PR TITLE
Simple directory listing caching and reloading in BoxProvider

### DIFF
--- a/qabelbox/src/main/java/de/qabel/qabelbox/providers/BoxProvider.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/providers/BoxProvider.java
@@ -4,13 +4,17 @@ import android.app.NotificationManager;
 import android.content.Context;
 import android.database.Cursor;
 import android.database.MatrixCursor;
+import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Bundle;
 import android.os.CancellationSignal;
 import android.os.Handler;
 import android.os.ParcelFileDescriptor;
+import android.provider.DocumentsContract;
 import android.provider.DocumentsContract.Document;
 import android.provider.DocumentsContract.Root;
 import android.provider.DocumentsProvider;
+import android.support.annotation.NonNull;
 import android.support.v7.app.NotificationCompat;
 import android.util.Log;
 
@@ -32,8 +36,10 @@ import java.io.InputStream;
 import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -86,6 +92,11 @@ public class BoxProvider extends DocumentsProvider {
     AmazonS3Client amazonS3Client;
     AWSCredentials awsCredentials;
 
+    // Flag that marks that the next request should try to serve the metadata from the cache
+    private boolean serveCachedData = true;
+
+    private Map<String, BoxCursor> folderContentCache;
+
     @Override
     public boolean onCreate() {
         mDocumentIdParser = new DocumentIdParser();
@@ -110,6 +121,8 @@ public class BoxProvider extends DocumentsProvider {
         };
         amazonS3Client = new AmazonS3Client(awsCredentials);
         QabelBoxApplication.boxProvider = this;
+
+        folderContentCache = new HashMap<>();
         return true;
     }
 
@@ -173,8 +186,7 @@ public class BoxProvider extends DocumentsProvider {
     public Cursor queryDocument(String documentId, String[] projection)
             throws FileNotFoundException {
         Log.d(TAG, "Query Document: " + documentId);
-        MatrixCursor cursor = new MatrixCursor(
-                reduceProjection(projection, DEFAULT_DOCUMENT_PROJECTION));
+        MatrixCursor cursor = createCursor(projection, false);
 
         String filePath = mDocumentIdParser.getFilePath(documentId);
 
@@ -239,8 +251,37 @@ public class BoxProvider extends DocumentsProvider {
     public Cursor queryChildDocuments(String parentDocumentId, String[] projection, String sortOrder)
             throws FileNotFoundException {
         Log.d(TAG, "Query Child Documents: " + parentDocumentId);
-        MatrixCursor cursor = new MatrixCursor(
-                reduceProjection(projection, DEFAULT_DOCUMENT_PROJECTION));
+        BoxCursor cursor;
+        if (serveCachedData) {
+            cursor = folderContentCache.get(parentDocumentId);
+            if (cursor == null) {
+                Log.d(TAG, "Serving empty listing from cache");
+                cursor = createCursor(projection, true);
+            } else {
+                Log.d(TAG, "Serving directory listing from cache");
+                cursor.setExtraLoading(true);
+            }
+            serveCachedData = false;
+            asyncChildDocuments(parentDocumentId, projection, cursor);
+        } else {
+            cursor = createBoxCursor(parentDocumentId, projection);
+            serveCachedData = true;
+        }
+		return cursor;
+    }
+
+	/**
+     * Create and fill a new MatrixCursor
+     *
+     * The cursor can be modified to show a loading and/or an error message.
+     *
+     * @param parentDocumentId
+     * @param projection
+     * @return Fully initialized cursor with the directory listing as rows
+     * @throws FileNotFoundException
+     */
+    private BoxCursor createBoxCursor(String parentDocumentId, String[] projection) throws FileNotFoundException {
+        BoxCursor cursor = createCursor(projection, false);
 
         BoxVolume volume = getVolumeForId(parentDocumentId);
         try {
@@ -252,6 +293,45 @@ public class BoxProvider extends DocumentsProvider {
             Log.e(TAG, "Could not navigate", e);
             throw new FileNotFoundException("Failed navigating the volume");
         }
+        folderContentCache.put(parentDocumentId, cursor);
+        return cursor;
+    }
+
+	/**
+     * Query the directory listing, store the cursor in the folderContentCache and
+     * notify the original cursor of the update.
+     *
+     * @param parentDocumentId
+     * @param projection
+     * @param result Original cursor
+     */
+    private void asyncChildDocuments(final String parentDocumentId, final String[] projection,
+                                     BoxCursor result) {
+        final Uri uri = DocumentsContract.buildChildDocumentsUri(AUTHORITY, parentDocumentId);
+        // tell the original cursor how he gets notified
+        result.setNotificationUri(getContext().getContentResolver(), uri);
+
+        // create a new cursor and store it
+        mThreadPoolExecutor.execute(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    createBoxCursor(parentDocumentId, projection);
+                } catch (FileNotFoundException e) {
+                    BoxCursor cursor = createCursor(projection, false);
+                    cursor.setError(getContext().getString(R.string.folderListingUpdateError));
+                    folderContentCache.put(parentDocumentId, cursor);
+                }
+                getContext().getContentResolver().notifyChange(uri, null);
+            }
+        });
+    }
+
+    @NonNull
+    private BoxCursor createCursor(String[] projection, final boolean extraLoading) {
+        String[] reduced = reduceProjection(projection, DEFAULT_DOCUMENT_PROJECTION);
+		BoxCursor cursor = new BoxCursor(reduced);
+        cursor.setExtraLoading(extraLoading);
         return cursor;
     }
 
@@ -560,7 +640,7 @@ public class BoxProvider extends DocumentsProvider {
 
         try {
             List<String> splitPath = mDocumentIdParser.splitPath(path);
-            String basename = splitPath.remove(splitPath.size()-1);
+            String basename = splitPath.remove(splitPath.size() - 1);
             BoxNavigation navigation = traverseToFolder(volume, splitPath);
             splitPath.add(PATH_SEP + displayName);
             String newPath = StringUtils.join(splitPath, "");
@@ -570,14 +650,14 @@ public class BoxProvider extends DocumentsProvider {
                     mDocumentIdParser.getPrefix(documentId),
                     newPath);
 
-            for (BoxFile file: navigation.listFiles()) {
+            for (BoxFile file : navigation.listFiles()) {
                 if (file.name.equals(basename)) {
                     navigation.rename(file, displayName);
                     navigation.commit();
                     return renamedId;
                 }
             }
-            for (BoxFolder folder: navigation.listFolders()) {
+            for (BoxFolder folder : navigation.listFolders()) {
                 if (folder.name.equals(basename)) {
                     navigation.rename(folder, displayName);
                     navigation.commit();
@@ -590,6 +670,32 @@ public class BoxProvider extends DocumentsProvider {
         } catch (QblStorageException e) {
             Log.e(TAG, "could not create file", e);
             throw new FileNotFoundException();
+        }
+    }
+
+    class BoxCursor extends MatrixCursor {
+        private boolean extraLoading;
+        private String error;
+
+        public BoxCursor(String[] columnNames) {
+            super(columnNames);
+        }
+
+        public void setExtraLoading(boolean loading) {
+            this.extraLoading = loading;
+        }
+
+        public Bundle getExtras() {
+            Bundle bundle = new Bundle();
+            bundle.putBoolean(DocumentsContract.EXTRA_LOADING, extraLoading);
+            if (error != null) {
+                bundle.putString(DocumentsContract.EXTRA_ERROR, error);
+            }
+            return bundle;
+        }
+
+        public void setError(String error) {
+            this.error = error;
         }
     }
 }

--- a/qabelbox/src/main/res/values/strings.xml
+++ b/qabelbox/src/main/res/values/strings.xml
@@ -18,4 +18,5 @@
     <string name="abort">Abort</string>
     <string name="Delete">Delete</string>
     <string name="Share">Share</string>
+    <string name="folderListingUpdateError">Failed to updated folder listing</string>
 </resources>


### PR DESCRIPTION
The BoxProvider now caches directory listings and updates them in the background. After updating,
the provider sends an update notification, so the client can use the updated cursor.

The cursors are all cached in a HashMap which is persistent until the BoxProvider is restarted.

Resolves #72 