### PR TITLE
Export files by calling the create document intent

### DIFF
--- a/qabelbox/src/main/java/de/qabel/qabelbox/fragments/FilesFragment.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/fragments/FilesFragment.java
@@ -18,6 +18,7 @@ import android.widget.ProgressBar;
 import de.qabel.qabelbox.storage.BoxNavigation;
 import de.qabel.qabelbox.R;
 import de.qabel.qabelbox.adapter.FilesAdapter;
+import de.qabel.qabelbox.storage.BoxObject;
 
 
 public class FilesFragment extends Fragment {
@@ -45,6 +46,11 @@ public class FilesFragment extends Fragment {
                 Snackbar.make(filesListRecyclerView, "Pos " + filesAdapter.getLongClickedPosition(), Snackbar.LENGTH_SHORT).show();
                 return true;
             case R.id.delete:
+                return true;
+            case R.id.export:
+                // Export handled in the MainActivity
+                BoxObject boxObject = filesAdapter.get(filesAdapter.getLongClickedPosition());
+                mListener.onExport(boxNavigation, boxObject);
                 return true;
             default:
                 return super.onContextItemSelected(item);
@@ -136,5 +142,6 @@ public class FilesFragment extends Fragment {
 
     public interface FilesListListener {
         void onScrolledToBottom(boolean scrolledToBottom);
+        void onExport(BoxNavigation boxNavigation, BoxObject object);
     }
 }

--- a/qabelbox/src/main/java/de/qabel/qabelbox/fragments/FilesFragment.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/fragments/FilesFragment.java
@@ -14,7 +14,9 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ProgressBar;
+import android.widget.Toast;
 
+import de.qabel.qabelbox.storage.BoxFolder;
 import de.qabel.qabelbox.storage.BoxNavigation;
 import de.qabel.qabelbox.R;
 import de.qabel.qabelbox.adapter.FilesAdapter;
@@ -50,6 +52,11 @@ public class FilesFragment extends Fragment {
             case R.id.export:
                 // Export handled in the MainActivity
                 BoxObject boxObject = filesAdapter.get(filesAdapter.getLongClickedPosition());
+                if (boxObject instanceof BoxFolder) {
+                    Toast.makeText(getActivity(), R.string.folder_export_not_implemented,
+                            Toast.LENGTH_SHORT).show();
+                    return true;
+                }
                 mListener.onExport(boxNavigation, boxObject);
                 return true;
             default:

--- a/qabelbox/src/main/res/menu/file_context_menu.xml
+++ b/qabelbox/src/main/res/menu/file_context_menu.xml
@@ -4,4 +4,6 @@
               android:title="@string/Share" />
         <item android:id="@+id/delete"
               android:title="@string/Delete" />
+        <item android:id="@+id/export"
+              android:title="@string/Export" />
 </menu>

--- a/qabelbox/src/main/res/values/strings.xml
+++ b/qabelbox/src/main/res/values/strings.xml
@@ -48,4 +48,5 @@
     <string name="Share">Share</string>
     <string name="folderListingUpdateError">Failed to updated folder listing</string>
     <string name="Export">Export</string>
+    <string name="folder_export_not_implemented">Exporting folders is not implemented</string>
 </resources>

--- a/qabelbox/src/main/res/values/strings.xml
+++ b/qabelbox/src/main/res/values/strings.xml
@@ -47,4 +47,5 @@
     <string name="Delete">Delete</string>
     <string name="Share">Share</string>
     <string name="folderListingUpdateError">Failed to updated folder listing</string>
+    <string name="Export">Export</string>
 </resources>


### PR DESCRIPTION
The long click menu in the FileFragment has an export option which
calls into a callback in the MainActivity. The Callback calls a
create document intent and uses that to copy the selected file to.

The export entry shows an error message when trying to export a folder.

Resolves #64