### PR TITLE
Use local time for mtime of files

### DIFF
--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/BoxTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/BoxTest.java
@@ -37,9 +37,7 @@ import de.qabel.qabelbox.exceptions.QblStorageException;
 import de.qabel.qabelbox.exceptions.QblStorageNameConflict;
 import de.qabel.qabelbox.exceptions.QblStorageNotFound;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 public class BoxTest extends AndroidTestCase {
@@ -143,7 +141,10 @@ public class BoxTest extends AndroidTestCase {
 
     private BoxFile uploadFile(BoxNavigation nav) throws QblStorageException, IOException {
         File file = new File(testFileName);
+        long time = System.currentTimeMillis() / 1000;
         BoxFile boxFile = nav.upload("foobar", new FileInputStream(file), null);
+        assertThat(boxFile.mtime, greaterThanOrEqualTo(time));
+        assertThat(boxFile.size, not(equalTo(boxFile.mtime)));
         nav.commit();
         checkFile(boxFile, nav);
         return boxFile;

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/AbstractNavigation.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/AbstractNavigation.java
@@ -73,10 +73,14 @@ public abstract class AbstractNavigation implements BoxNavigation {
 								  File file, @Nullable TransferManager.BoxTransferListener boxTransferListener) {
 		int id = transferManager.upload(name, file, boxTransferListener);
 		transferManager.waitFor(id);
-		return file.length();
+		return currentSecondsFromEpoch();
 	}
 
-    /**
+	private static long currentSecondsFromEpoch() {
+		return System.currentTimeMillis() / 1000;
+	}
+
+	/**
      * Navigates to a direct subfolder.
      * @param target Subfolder to navigate to
      * @throws QblStorageException


### PR DESCRIPTION
Since we don't get a time from the AWS response because we use the
TranserUtility, we need to use the local time.

Resolves #87