### PR TITLE
Integrate identity management into Box

### DIFF
--- a/qabelbox/build.gradle
+++ b/qabelbox/build.gradle
@@ -17,7 +17,7 @@ spoon {
 
 android {
     compileSdkVersion 22
-    buildToolsVersion '23.0.2'
+    buildToolsVersion '22.0.1'
 
     defaultConfig {
         applicationId "de.qabel.qabelbox"

--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/providers/BoxProviderTester.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/providers/BoxProviderTester.java
@@ -1,0 +1,112 @@
+package de.qabel.qabelbox.providers;
+
+import android.Manifest;
+import android.content.Context;
+import android.content.pm.ProviderInfo;
+
+import org.spongycastle.util.encoders.Hex;
+
+import java.util.UUID;
+
+import de.qabel.core.config.Identities;
+import de.qabel.core.config.Identity;
+import de.qabel.core.crypto.CryptoUtils;
+import de.qabel.core.crypto.QblECKeyPair;
+import de.qabel.core.exceptions.QblInvalidEncryptionKeyException;
+import de.qabel.qabelbox.config.AndroidPersistence;
+import de.qabel.qabelbox.config.QblSQLiteParams;
+import de.qabel.qabelbox.services.LocalQabelService;
+
+public class BoxProviderTester extends BoxProvider {
+
+	public byte[] deviceID;
+	public String lastID;
+	public QblECKeyPair keyPair;
+	public String rootDocId;
+	public final String prefix = UUID.randomUUID().toString();
+	public static final String PUB_KEY = "8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a";
+	public static final String PRIVATE_KEY = "77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a";
+	public Identity identity;
+
+
+	@Override
+	void bindToService(final Context context) {
+		setParametersForTests();
+		initServiceForTests(context);
+		attachInfoForTests(context);
+	}
+
+	private void setParametersForTests() {
+		CryptoUtils utils = new CryptoUtils();
+		deviceID = utils.getRandomBytes(16);
+		keyPair = new QblECKeyPair(Hex.decode(PRIVATE_KEY));
+		rootDocId = PUB_KEY + BoxProvider.DOCID_SEPARATOR + BoxProvider.BUCKET
+				+ BoxProvider.DOCID_SEPARATOR + prefix + BoxProvider.DOCID_SEPARATOR
+				+ BoxProvider.PATH_SEP;
+		identity = new Identity("testuser", null, keyPair);
+	}
+
+	private void initServiceForTests(Context context) {
+		mService = new MockedLocalQabelService(context);
+		mService.onCreate();
+	}
+
+	private void attachInfoForTests(Context context) {
+		ProviderInfo info = new ProviderInfo();
+		info.authority = AUTHORITY;
+		info.exported = true;
+		info.grantUriPermissions = true;
+		info.readPermission = Manifest.permission.MANAGE_DOCUMENTS;
+		info.writePermission = Manifest.permission.MANAGE_DOCUMENTS;
+		attachInfo(context, info);
+	}
+
+
+	private class MockedLocalQabelService extends LocalQabelService {
+
+		private final Context context;
+
+		public MockedLocalQabelService(Context context) {
+			this.context = context;
+		}
+
+		@Override
+		public byte[] getDeviceID() {
+			return deviceID;
+		}
+
+		@Override
+		protected void setLastActiveIdentityID(String identityID) {
+			lastID = identityID;
+		}
+
+		@Override
+		protected String getLastActiveIdentityID() {
+			return lastID;
+		}
+
+		@Override
+		protected void initSharedPreferences() {
+		}
+
+		@Override
+		protected void initAndroidPersistence() {
+			AndroidPersistence androidPersistence;
+			QblSQLiteParams params = new QblSQLiteParams(context, DB_NAME, null, DB_VERSION);
+			try {
+				androidPersistence = new AndroidPersistence(params, PASSWORD);
+			} catch (QblInvalidEncryptionKeyException e) {
+				return;
+			}
+			this.persistence = androidPersistence;
+		}
+
+		@Override
+		public Identities getIdentities() {
+			Identities identities = new Identities();
+			identities.put(identity);
+			return identities;
+		}
+	}
+}
+

--- a/qabelbox/src/main/java/de/qabel/qabelbox/activities/MainActivity.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/activities/MainActivity.java
@@ -41,24 +41,14 @@ import org.apache.commons.io.IOUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.Serializable;
 import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 
-import de.qabel.ackack.MessageInfo;
-import de.qabel.ackack.Responsible;
-import de.qabel.ackack.event.EventActor;
-import de.qabel.ackack.event.EventListener;
-import de.qabel.core.EventNameConstants;
 import de.qabel.core.config.Contact;
-import de.qabel.core.config.Contacts;
-import de.qabel.core.config.Identities;
 import de.qabel.core.config.Identity;
-import de.qabel.core.config.ResourceActor;
 import de.qabel.qabelbox.QabelBoxApplication;
 import de.qabel.qabelbox.R;
 import de.qabel.qabelbox.adapter.FilesAdapter;
@@ -96,8 +86,8 @@ public class MainActivity extends AppCompatActivity
     private static final String TAG = "BoxMainActivity";
     private static final int REQUEST_CODE_OPEN = 11;
     private static final int REQUEST_CODE_UPLOAD_FILE = 12;
-    public static final String HARDCODED_ROOT = BoxProvider.PUB_KEY
-            + BoxProvider.DOCID_SEPARATOR + BoxProvider.BUCKET + BoxProvider.DOCID_SEPARATOR
+    public static final String HARDCODED_ROOT = BoxProvider.DOCID_SEPARATOR
+            + BoxProvider.BUCKET + BoxProvider.DOCID_SEPARATOR
             + BoxProvider.PREFIX + BoxProvider.DOCID_SEPARATOR + BoxProvider.PATH_SEP;
     private static final int REQUEST_CODE_DELETE_FILE = 13;
     private static final int REQUEST_CODE_CHOOSE_EXPORT = 14;
@@ -200,8 +190,10 @@ public class MainActivity extends AppCompatActivity
         String displayName = cursor.getString(
                 cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME));
         Log.i(TAG, "Displayname: " + displayName);
+        String keyIdentifier = mService.getActiveIdentity().getEcPublicKey()
+                .getReadableKeyIdentifier();
         Uri uploadUri = DocumentsContract.buildDocumentUri(
-                BoxProvider.AUTHORITY, HARDCODED_ROOT + targetFolder + displayName);
+                BoxProvider.AUTHORITY, keyIdentifier + HARDCODED_ROOT + targetFolder + displayName);
         try {
             OutputStream outputStream = getContentResolver().openOutputStream(uploadUri, "w");
             if (outputStream == null) {
@@ -281,9 +273,9 @@ public class MainActivity extends AppCompatActivity
 
         provider = ((QabelBoxApplication) getApplication()).getProvider();
         Log.i(TAG, "Provider: " + provider);
-		provider.setLocalService(mService);
 
-        boxVolume = provider.getVolumeForRoot(null, null, null);
+        provider.setLocalService(mService);
+        initBoxVolume();
 
         initFilesFragment();
         initDrawer();
@@ -333,6 +325,12 @@ public class MainActivity extends AppCompatActivity
     private void initBoxVolume(Identity activeIdentity) {
         boxVolume = provider.getVolumeForRoot(
                 activeIdentity.getEcPublicKey().getReadableKeyIdentifier(),
+                null, null);
+    }
+
+    private void initBoxVolume() {
+        boxVolume = provider.getVolumeForRoot(
+                mService.getActiveIdentity().getEcPublicKey().getReadableKeyIdentifier(),
                 null, null);
     }
 
@@ -666,16 +664,16 @@ public class MainActivity extends AppCompatActivity
     }
 
     public void selectIdentity(Identity identity) {
-        mService.setActiveIdentity(identity);
-        selectContactsFragment();
+        changeActiveIdentity(identity);
 
-        textViewSelectedIdentity.setText(identity.getAlias());
+        selectContactsFragment();
     }
 
     @Override
     public void addIdentity(Identity identity) {
         mService.addIdentity(identity);
-        mService.setActiveIdentity(identity);
+        changeActiveIdentity(identity);
+        provider.notifyRootsUpdated();
 
         Snackbar.make(appBarMain, "Added identity: " + identity.getAlias(), Snackbar.LENGTH_LONG)
                 .show();
@@ -688,6 +686,14 @@ public class MainActivity extends AppCompatActivity
         initFilesFragment();
 
         selectFilesFragment();
+    }
+
+    private void changeActiveIdentity(Identity identity) {
+        mService.setActiveIdentity(identity);
+        textViewSelectedIdentity.setText(identity.getAlias());
+        getFragmentManager().beginTransaction().remove(filesFragment).commit();
+        initBoxVolume();
+        initFilesFragment();
     }
 
     @Override
@@ -713,11 +719,13 @@ public class MainActivity extends AppCompatActivity
 
     @Override
     public void deleteIdentity(Identity identity) {
+        provider.notifyRootsUpdated();
         mService.deleteIdentity(identity);
     }
 
     @Override
     public void modifyIdentity(Identity identity) {
+        provider.notifyRootsUpdated();
         mService.modifyIdentity(identity);
     }
 

--- a/qabelbox/src/main/java/de/qabel/qabelbox/services/LocalQabelService.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/services/LocalQabelService.java
@@ -38,18 +38,18 @@ public class LocalQabelService extends Service {
 
 	private final IBinder mBinder = new LocalBinder();
 
-	static final String DB_NAME = "qabel-service";
-	private static final int DB_VERSION = 1;
-	private AndroidPersistence persistence;
-	private SharedPreferences sharedPreferences;
+	protected static final String DB_NAME = "qabel-service";
+	protected static final int DB_VERSION = 1;
+	protected AndroidPersistence persistence;
+	SharedPreferences sharedPreferences;
 
-	private void setLastActiveIdentityID(String identityID) {
+	protected void setLastActiveIdentityID(String identityID) {
 		sharedPreferences.edit()
 				.putString(PREF_LAST_ACTIVE_IDENTITY, identityID)
 				.apply();
 	}
 
-	private String getLastActiveIdentityID() {
+	protected String getLastActiveIdentityID() {
 		return sharedPreferences.getString(PREF_LAST_ACTIVE_IDENTITY, "");
 	}
 
@@ -181,7 +181,11 @@ public class LocalQabelService extends Service {
 	public void onCreate() {
 		super.onCreate();
 		Log.i(TAG, "LocalQabelService created");
-		sharedPreferences = getSharedPreferences(this.getClass().getCanonicalName(), MODE_PRIVATE);
+		initSharedPreferences();
+		initAndroidPersistence();
+	}
+
+	protected void initAndroidPersistence() {
 		AndroidPersistence androidPersistence;
 		QblSQLiteParams params = new QblSQLiteParams(this, DB_NAME, null, DB_VERSION);
 		try {
@@ -191,6 +195,10 @@ public class LocalQabelService extends Service {
 			return;
 		}
 		this.persistence = androidPersistence;
+	}
+
+	protected void initSharedPreferences() {
+		sharedPreferences = getSharedPreferences(this.getClass().getCanonicalName(), MODE_PRIVATE);
 		if (!sharedPreferences.getBoolean(PREF_DEVICE_ID_CREATED, false)) {
 
 			CryptoUtils cryptoUtils = new CryptoUtils();
@@ -202,7 +210,6 @@ public class LocalQabelService extends Service {
 					.putBoolean(PREF_DEVICE_ID_CREATED, true)
 					.apply();
 		}
-
 	}
 
 	@Override


### PR DESCRIPTION
The FileFragment should use the current identity and the BoxProvider should use all identities available.

Resolves #116 

#43 has to include the prefix management which changes the FileFragment and the BoxProvider to use Volume configs consisting of (prefix, identity) instead of just the identity.