### PR TITLE
Jenkins build badge added to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # qabel-android
+
+[![Build Status](https://jenkins.prae.me/buildStatus/icon?job=qabel-android-nightly)](https://jenkins.prae.me/job/qabel-android-nightly/)


### PR DESCRIPTION
It's badge. For the build. It has a status. It should be green.

It uses the nightly build status.