### PR TITLE
Import and export identities

### DIFF
--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/config/ContactExportImportTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/config/ContactExportImportTest.java
@@ -16,7 +16,7 @@ import de.qabel.core.exceptions.QblDropInvalidURL;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-public class ResourceExportImportTest {
+public class ContactExportImportTest {
 
     @Test
     public void testExportIdentityAsContact() throws URISyntaxException, QblDropInvalidURL {
@@ -27,7 +27,7 @@ public class ResourceExportImportTest {
                         "http://localhost:6000/1234567890123456789012345678901234567891234"));
         Identity identity = new Identity("Identity", dropURLs, qblECKeyPair);
 
-        assertThat(ResourceExportImport.exportIdentityAsContact(identity), is("{\"QABELALIAS\":\"Identity\",\"QABELDROPURL\":" +
+        assertThat(ContactExportImport.exportIdentityAsContact(identity), is("{\"QABELALIAS\":\"Identity\",\"QABELDROPURL\":" +
                         "[\"http:\\/\\/localhost:6000\\/1234567890123456789012345678901234567891234\"]," +
                         "\"QABELKEYIDENTIFIER\":\"" + qblECKeyPair.getPub().getReadableKeyIdentifier() + "\"}"));
     }
@@ -45,9 +45,9 @@ public class ResourceExportImportTest {
 
         Identity identity = new Identity("Identity", dropURLs, qblECKeyPair);
 
-        String json = ResourceExportImport.exportIdentityAsContact(identity);
+        String json = ContactExportImport.exportIdentityAsContact(identity);
         // Normally a contact wouldn't be imported for the belonging identity, but it doesn't matter for the test
-        Contact contact = ResourceExportImport.parseContactForIdentity(identity, json);
+        Contact contact = ContactExportImport.parseContactForIdentity(identity, json);
 
         assertThat(identity.getAlias(), is(contact.getAlias()));
         assertThat(identity.getDropUrls(), is(contact.getDropUrls()));

--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/config/IdentityExportImportTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/config/IdentityExportImportTest.java
@@ -1,0 +1,66 @@
+package de.qabel.qabelbox.config;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import de.qabel.core.config.Identity;
+import de.qabel.core.crypto.QblECKeyPair;
+import de.qabel.core.drop.DropURL;
+
+import static org.junit.Assert.*;
+
+public class IdentityExportImportTest {
+
+	@Test
+	public void testExportImportIdentity() throws Exception {
+		QblECKeyPair qblECKeyPair = new QblECKeyPair();
+		Collection<DropURL> dropURLs = new ArrayList<>();
+		dropURLs.add(new DropURL("http://localhost:6000/1234567890123456789012345678901234567891234"));
+		dropURLs.add(new DropURL("http://localhost:6000/0000000000000000000000000000000000000000000"));
+
+		Identity identity = new Identity("Identity", dropURLs, qblECKeyPair);
+		identity.setPhone("049111111");
+		identity.setEmail("test@example.com");
+
+		String exportedIdentity = IdentityExportImport.exportIdentity(identity);
+
+		Identity importedIdentity = IdentityExportImport.parseIdentity(exportedIdentity);
+
+		assertEquals(identity, importedIdentity);
+		assertEquals(identity.getId(), importedIdentity.getId());
+		assertEquals(identity.getCreated(), importedIdentity.getCreated());
+		assertEquals(identity.getUpdated(), importedIdentity.getUpdated());
+		assertEquals(identity.getDeleted(), importedIdentity.getDeleted());
+		assertEquals(identity.getEmail(), importedIdentity.getEmail());
+		assertEquals(identity.getPhone(), importedIdentity.getPhone());
+		assertEquals(identity.getPrimaryKeyPair(), importedIdentity.getPrimaryKeyPair());
+		assertEquals(identity.getDropUrls(), importedIdentity.getDropUrls());
+	}
+
+	@Test
+	public void testExportImportIdentityMissingOptionals() throws Exception {
+		QblECKeyPair qblECKeyPair = new QblECKeyPair();
+		Collection<DropURL> dropURLs = new ArrayList<>();
+		dropURLs.add(new DropURL("http://localhost:6000/1234567890123456789012345678901234567891234"));
+		dropURLs.add(new DropURL("http://localhost:6000/0000000000000000000000000000000000000000000"));
+
+		Identity identity = new Identity("Identity", dropURLs, qblECKeyPair);
+
+		String exportedIdentity = IdentityExportImport.exportIdentity(identity);
+
+		Identity importedIdentity = IdentityExportImport.parseIdentity(exportedIdentity);
+
+		assertEquals(identity, importedIdentity);
+		assertEquals(identity.getId(), importedIdentity.getId());
+		assertEquals(identity.getCreated(), importedIdentity.getCreated());
+		assertEquals(identity.getUpdated(), importedIdentity.getUpdated());
+		assertEquals(identity.getDeleted(), importedIdentity.getDeleted());
+		assertEquals(identity.getEmail(), importedIdentity.getEmail());
+		assertEquals(identity.getPhone(), importedIdentity.getPhone());
+		assertEquals(identity.getPrimaryKeyPair(), importedIdentity.getPrimaryKeyPair());
+		assertEquals(identity.getDropUrls(), importedIdentity.getDropUrls());
+	}
+
+}

--- a/qabelbox/src/main/java/de/qabel/qabelbox/activities/CreateIdentityActivity.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/activities/CreateIdentityActivity.java
@@ -31,6 +31,8 @@ import de.qabel.qabelbox.services.LocalQabelService;
  */
 public class CreateIdentityActivity extends BaseWizardActivity {
 
+    public static final int REQUEST_CODE_IMPORT_IDENTITY = 1;
+
     private String TAG = this.getClass().getSimpleName();
 
     private String mIdentityName;

--- a/qabelbox/src/main/java/de/qabel/qabelbox/activities/MainActivity.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/activities/MainActivity.java
@@ -93,6 +93,7 @@ public class MainActivity extends AppCompatActivity
     private static final int REQUEST_CODE_CHOOSE_EXPORT = 14;
     private static final int REQUEST_CREATE_IDENTITY = 16;
     private static final int REQUEST_SETTINGS = 17;
+    public static final int REQUEST_EXPORT_IDENTITY = 18;
     private static final String FALLBACK_MIMETYPE = "application/octet-stream";
     private static final int NAV_GROUP_IDENTITIES = 1;
     private static final int NAV_GROUP_IDENTITY_ACTIONS = 2;

--- a/qabelbox/src/main/java/de/qabel/qabelbox/config/ContactExportImport.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/config/ContactExportImport.java
@@ -16,11 +16,11 @@ import de.qabel.core.crypto.QblECPublicKey;
 import de.qabel.core.drop.DropURL;
 import de.qabel.core.exceptions.QblDropInvalidURL;
 
-public class ResourceExportImport {
+public class ContactExportImport {
 
-    private static final String TAG_QABEL_ALIAS = "QABELALIAS";
-    private static final String TAG_QABEL_DROP_URLS = "QABELDROPURL";
-    private static final String TAG_QABEL_KEY_IDENTIFIER = "QABELKEYIDENTIFIER";
+    private static final String KEY_ALIAS = "QABELALIAS";
+    private static final String KEY_DROP_URLS = "QABELDROPURL";
+    private static final String KEY_KEY_IDENTIFIER = "QABELKEYIDENTIFIER";
 
     /**
      * Exports the {@link Contact} information as a JSON string from an {@link Identity}
@@ -31,12 +31,12 @@ public class ResourceExportImport {
         JSONObject jsonObject = new JSONObject();
         JSONArray jsonDropUrls = new JSONArray();
         try {
-            jsonObject.put(TAG_QABEL_ALIAS, identity.getAlias());
+            jsonObject.put(KEY_ALIAS, identity.getAlias());
             for (DropURL dropURL : identity.getDropUrls()) {
                 jsonDropUrls.put(dropURL);
             }
-            jsonObject.put(TAG_QABEL_DROP_URLS, jsonDropUrls);
-            jsonObject.put(TAG_QABEL_KEY_IDENTIFIER, identity.getKeyIdentifier());
+            jsonObject.put(KEY_DROP_URLS, jsonDropUrls);
+            jsonObject.put(KEY_KEY_IDENTIFIER, identity.getKeyIdentifier());
         } catch (JSONException e) {
             // Shouldn't be possible to trigger this exception
             throw new RuntimeException("Cannot build JSONObject", e);
@@ -58,12 +58,12 @@ public class ResourceExportImport {
         JSONObject jsonObject = new JSONObject(json);
 
         Collection<DropURL> dropURLs = new ArrayList<>();
-        String alias = jsonObject.getString(TAG_QABEL_ALIAS);
-        JSONArray jsonDropURLS = jsonObject.getJSONArray(TAG_QABEL_DROP_URLS);
+        String alias = jsonObject.getString(KEY_ALIAS);
+        JSONArray jsonDropURLS = jsonObject.getJSONArray(KEY_DROP_URLS);
         for (int i = 0; i < jsonDropURLS.length(); i++) {
             dropURLs.add(new DropURL(jsonDropURLS.getString(i)));
         }
-        String keyIdentifier = jsonObject.getString(TAG_QABEL_KEY_IDENTIFIER);
+        String keyIdentifier = jsonObject.getString(KEY_KEY_IDENTIFIER);
 
         return new Contact(identity, alias, dropURLs, new QblECPublicKey(Hex.decode(keyIdentifier)));
     }

--- a/qabelbox/src/main/java/de/qabel/qabelbox/config/IdentityExportImport.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/config/IdentityExportImport.java
@@ -1,0 +1,105 @@
+package de.qabel.qabelbox.config;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.spongycastle.util.encoders.Hex;
+
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import de.qabel.core.config.Identity;
+import de.qabel.core.crypto.QblECKeyPair;
+import de.qabel.core.drop.DropURL;
+import de.qabel.core.exceptions.QblDropInvalidURL;
+
+public class IdentityExportImport {
+
+	private static final String KEY_ID = "id";
+	private static final String KEY_CREATED = "created";
+	private static final String KEY_UPDATED = "updated";
+	private static final String KEY_DELETED = "deleted";
+	private static final String KEY_ALIAS = "alias";
+	private static final String KEY_EMAIL = "email";
+	private static final String KEY_PHONE = "phone";
+	private static final String KEY_PRIVATE_KEY = "private_key";
+	private static final String KEY_PUBLIC_KEY = "public_key";
+	private static final String KEY_DROP_URLS = "drop_urls";
+
+	/**
+	 * @param identity {@link Identity} to export
+	 * @return {@link Identity} information as JSON string
+	 */
+	public static String exportIdentity(Identity identity) {
+		JSONObject jsonObject = new JSONObject();
+		JSONArray jsonDropUrls = new JSONArray();
+
+		try {
+			jsonObject.put(KEY_ID, identity.getId());
+			jsonObject.put(KEY_CREATED, identity.getCreated());
+			jsonObject.put(KEY_UPDATED, identity.getUpdated());
+			jsonObject.put(KEY_DELETED, identity.getDeleted());
+			jsonObject.put(KEY_ALIAS, identity.getAlias());
+			jsonObject.put(KEY_EMAIL, identity.getEmail());
+			jsonObject.put(KEY_PHONE, identity.getPhone());
+			jsonObject.put(KEY_PRIVATE_KEY, Hex.toHexString(identity.getPrimaryKeyPair().getPrivateKey()));
+			jsonObject.put(KEY_PUBLIC_KEY, Hex.toHexString(identity.getEcPublicKey().getKey()));
+
+			for (DropURL dropURL : identity.getDropUrls()) {
+				jsonDropUrls.put(dropURL);
+			}
+			jsonObject.put(KEY_DROP_URLS, jsonDropUrls);
+		} catch (JSONException e) {
+			// Shouldn't be possible to trigger this exception
+			throw new RuntimeException("Cannot build JSONObject", e);
+		}
+
+		return jsonObject.toString();
+	}
+
+	/**
+	 * Parse a {@link Identity} from a {@link Identity} JSON string
+	 * @param json {@link Identity} JSON string
+	 * @return {@link Identity} parsed from JSON string
+	 * @throws JSONException
+	 * @throws URISyntaxException
+	 * @throws QblDropInvalidURL
+	 */
+	public static Identity parseIdentity(String json) throws JSONException, URISyntaxException, QblDropInvalidURL {
+		Collection<DropURL> dropURLs = new ArrayList<>();
+
+		JSONObject jsonObject = new JSONObject(json);
+		String alias = jsonObject.getString(KEY_ALIAS);
+		JSONArray jsonDropURLS = jsonObject.getJSONArray(KEY_DROP_URLS);
+		for (int i = 0; i < jsonDropURLS.length(); i++) {
+			dropURLs.add(new DropURL(jsonDropURLS.getString(i)));
+		}
+
+		QblECKeyPair qblECKeyPair = new QblECKeyPair(Hex.decode(jsonObject.getString(KEY_PRIVATE_KEY)));
+
+		Identity identity = new Identity(alias, dropURLs, qblECKeyPair);
+
+		if (jsonObject.has(KEY_ID)) {
+			identity.setId(jsonObject.getInt(KEY_ID));
+		}
+		if (jsonObject.has(KEY_CREATED)) {
+			identity.setCreated(jsonObject.getLong(KEY_CREATED));
+		}
+		if (jsonObject.has(KEY_UPDATED)) {
+			identity.setUpdated(jsonObject.getLong(KEY_UPDATED));
+		}
+		if (jsonObject.has(KEY_DELETED)) {
+			identity.setDeleted(jsonObject.getLong(KEY_DELETED));
+		}
+		if (jsonObject.has(KEY_EMAIL)) {
+			identity.setEmail(jsonObject.getString(KEY_EMAIL));
+		}
+		if (jsonObject.has(KEY_PHONE)) {
+			identity.setPhone(jsonObject.getString(KEY_PHONE));
+		}
+
+		return identity;
+	}
+
+}

--- a/qabelbox/src/main/res/values/strings.xml
+++ b/qabelbox/src/main/res/values/strings.xml
@@ -154,4 +154,5 @@
     <string name="change_account_password_newpassword2_hint">New password again</string>
     <string name="btn_reset_password">Reset password</string>
     <string name="create_account_reset_password_infos">Enter your email address that you entered until the account registration</string>
+    <string name="cant_read_identity">Can\'t read identity from file</string>
 </resources>

--- a/qabelbox/src/main/res/values/strings.xml
+++ b/qabelbox/src/main/res/values/strings.xml
@@ -155,4 +155,6 @@
     <string name="btn_reset_password">Reset password</string>
     <string name="create_account_reset_password_infos">Enter your email address that you entered until the account registration</string>
     <string name="cant_read_identity">Can\'t read identity from file</string>
+    <string name="identity_export_failed">Identity export failed!</string>
+    <string name="identity_export_complete">Identity exported</string>
 </resources>


### PR DESCRIPTION
Based on #204 

Identities can now be exported and imported into a JSON file. File selection is done via DocumentsProvider.

Closes #37 
Closes #38 