### PR TITLE
Changed ContactExportImport to documented Contact JSON format

### DIFF
--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/config/ContactExportImportTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/config/ContactExportImportTest.java
@@ -58,6 +58,15 @@ public class ContactExportImportTest {
 	}
 
 	@Test
+	public void testExportImportContactWithOptionals() throws QblDropInvalidURL, JSONException, URISyntaxException {
+		contact1.setEmail("test@example.com");
+		contact1.setPhone("+491111111");
+		String contactJSON = ContactExportImport.exportContact(contact1);
+		Contact importedContact1 = ContactExportImport.parseContactForIdentity(identity, contactJSON);
+		contactEquals(contact1, importedContact1);
+	}
+
+	@Test
 	public void testExportImportContacts() throws JSONException, URISyntaxException, QblDropInvalidURL {
 		String contactsJSON = ContactExportImport.exportContacts(contacts);
 

--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/config/ContactExportImportTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/config/ContactExportImportTest.java
@@ -1,6 +1,7 @@
 package de.qabel.qabelbox.config;
 
 import org.json.JSONException;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.net.URISyntaxException;
@@ -8,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import de.qabel.core.config.Contact;
+import de.qabel.core.config.Contacts;
 import de.qabel.core.config.Identity;
 import de.qabel.core.crypto.QblECKeyPair;
 import de.qabel.core.drop.DropURL;
@@ -18,39 +20,75 @@ import static org.hamcrest.core.Is.is;
 
 public class ContactExportImportTest {
 
+	private static final String DROP_URL_1 = "http://localhost:6000/1234567890123456789012345678901234567891234";
+	private static final String DROP_URL_2 = "http://localhost:6000/0000000000000000000000000000000000000000000";
+
+	Identity identity;
+	Contact contact1;
+	Contact contact2;
+	Contacts contacts;
+	QblECKeyPair qblECKeyPair;
+
+	@Before
+	public void setUp() throws Exception {
+		qblECKeyPair = new QblECKeyPair();
+		Collection<DropURL> dropURLs = new ArrayList<>();
+		dropURLs.add(new DropURL(DROP_URL_1));
+		dropURLs.add(new DropURL(DROP_URL_2));
+		identity = new Identity("Identity", dropURLs, qblECKeyPair);
+		identity.setEmail("test@example.com");
+		identity.setPhone("+491111111");
+
+		QblECKeyPair contact1KeyPair = new QblECKeyPair();
+		contact1 = new Contact(identity,  "Contact1", dropURLs, contact1KeyPair.getPub());
+
+		QblECKeyPair contact2KeyPair = new QblECKeyPair();
+		contact2 = new Contact(identity, "Contact2", dropURLs, contact2KeyPair.getPub());
+
+		contacts = new Contacts();
+		contacts.put(contact1);
+		contacts.put(contact2);
+	}
+
+	@Test
+	public void testExportImportContact() throws QblDropInvalidURL, JSONException, URISyntaxException {
+		String contactJSON = ContactExportImport.exportContact(contact1);
+		Contact importedContact1 = ContactExportImport.parseContactForIdentity(identity, contactJSON);
+		contactEquals(contact1, importedContact1);
+	}
+
+	@Test
+	public void testExportImportContacts() throws JSONException, URISyntaxException, QblDropInvalidURL {
+		String contactsJSON = ContactExportImport.exportContacts(contacts);
+
+		Contacts importedContacts = ContactExportImport.parseContactsForIdentity(identity, contactsJSON);
+
+		assertThat(importedContacts.getContacts().size(), is(2));
+		Contact importedContact1 = importedContacts.getByKeyIdentifier(contact1.getKeyIdentifier());
+		Contact importedContact2 = importedContacts.getByKeyIdentifier(contact2.getKeyIdentifier());
+
+		contactEquals(contact1, importedContact1);
+		contactEquals(contact2, importedContact2);
+	}
+
+	private void contactEquals(Contact contact1, Contact contact2){
+		assertThat(contact1.getAlias(), is(contact2.getAlias()));
+		assertThat(contact1.getDropUrls(), is(contact2.getDropUrls()));
+		assertThat(contact1.getEcPublicKey().getReadableKeyIdentifier(), is(contact2.getEcPublicKey().getReadableKeyIdentifier()));
+		assertThat(contact1.getPhone(), is(contact2.getPhone()));
+		assertThat(contact1.getEmail(), is(contact2.getEmail()));
+	}
+
     @Test
-    public void testExportIdentityAsContact() throws URISyntaxException, QblDropInvalidURL {
-        QblECKeyPair qblECKeyPair = new QblECKeyPair();
-        Collection<DropURL> dropURLs = new ArrayList<>();
-        dropURLs.add(
-                new DropURL(
-                        "http://localhost:6000/1234567890123456789012345678901234567891234"));
-        Identity identity = new Identity("Identity", dropURLs, qblECKeyPair);
-
-        assertThat(ContactExportImport.exportIdentityAsContact(identity), is("{\"QABELALIAS\":\"Identity\",\"QABELDROPURL\":" +
-                        "[\"http:\\/\\/localhost:6000\\/1234567890123456789012345678901234567891234\"]," +
-                        "\"QABELKEYIDENTIFIER\":\"" + qblECKeyPair.getPub().getReadableKeyIdentifier() + "\"}"));
-    }
-
-    @Test
-    public void testImportExportedContact() throws URISyntaxException, QblDropInvalidURL, JSONException {
-        QblECKeyPair qblECKeyPair = new QblECKeyPair();
-        Collection<DropURL> dropURLs = new ArrayList<>();
-        dropURLs.add(
-                new DropURL(
-                        "http://localhost:6000/1234567890123456789012345678901234567891234"));
-        dropURLs.add(
-                new DropURL(
-                        "http://localhost:6000/0000000000000000000000000000000000000000000"));
-
-        Identity identity = new Identity("Identity", dropURLs, qblECKeyPair);
-
-        String json = ContactExportImport.exportIdentityAsContact(identity);
+    public void testImportExportedContactFromIdentity() throws URISyntaxException, QblDropInvalidURL, JSONException {
+         String json = ContactExportImport.exportIdentityAsContact(identity);
         // Normally a contact wouldn't be imported for the belonging identity, but it doesn't matter for the test
         Contact contact = ContactExportImport.parseContactForIdentity(identity, json);
 
         assertThat(identity.getAlias(), is(contact.getAlias()));
         assertThat(identity.getDropUrls(), is(contact.getDropUrls()));
         assertThat(identity.getEcPublicKey().getReadableKeyIdentifier(), is(contact.getEcPublicKey().getReadableKeyIdentifier()));
+		assertThat(identity.getPhone(), is(contact.getPhone()));
+		assertThat(identity.getEmail(), is(contact.getEmail()));
     }
 }

--- a/qabelbox/src/main/java/de/qabel/qabelbox/activities/MainActivity.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/activities/MainActivity.java
@@ -744,7 +744,15 @@ public class MainActivity extends AppCompatActivity
     @Override
     public void addContact(Contact contact) {
 
-        mService.addContact(contact);
+		for (Contact c : mService.getContacts().getContacts()) {
+			if (c.getKeyIdentifier().equals(contact.getKeyIdentifier())) {
+				Snackbar.make(appBarMain, "Contact already existing: " + contact.getAlias(), Snackbar.LENGTH_LONG)
+						.show();
+				return;
+			}
+		}
+
+		mService.addContact(contact);
         Snackbar.make(appBarMain, "Added contact: " + contact.getAlias(), Snackbar.LENGTH_LONG)
                 .show();
     }

--- a/qabelbox/src/main/java/de/qabel/qabelbox/activities/MainActivity.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/activities/MainActivity.java
@@ -53,6 +53,7 @@ import de.qabel.core.config.Identity;
 import de.qabel.qabelbox.QabelBoxApplication;
 import de.qabel.qabelbox.R;
 import de.qabel.qabelbox.adapter.FilesAdapter;
+import de.qabel.qabelbox.config.ContactExportImport;
 import de.qabel.qabelbox.exceptions.QblStorageException;
 import de.qabel.qabelbox.fragments.AddContactFragment;
 import de.qabel.qabelbox.fragments.BaseFragment;
@@ -863,10 +864,7 @@ public class MainActivity extends AppCompatActivity
                 Identity activeIdentity = mService.getActiveIdentity();
                 if (activeIdentity != null) {
                     IntentIntegrator intentIntegrator = new IntentIntegrator(self);
-                    intentIntegrator.shareText("QABELCONTACT\n"
-                            + activeIdentity.getAlias() + "\n"
-                            + activeIdentity.getDropUrls().toArray()[0].toString() + "\n"
-                            + activeIdentity.getKeyIdentifier());
+                    intentIntegrator.shareText(ContactExportImport.exportIdentityAsContact(activeIdentity));
                 }
             }
         });

--- a/qabelbox/src/main/java/de/qabel/qabelbox/config/ContactExportImport.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/config/ContactExportImport.java
@@ -1,6 +1,8 @@
 package de.qabel.qabelbox.config;
 
 
+import android.support.annotation.NonNull;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -11,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import de.qabel.core.config.Contact;
+import de.qabel.core.config.Contacts;
 import de.qabel.core.config.Identity;
 import de.qabel.core.crypto.QblECPublicKey;
 import de.qabel.core.drop.DropURL;
@@ -18,11 +21,48 @@ import de.qabel.core.exceptions.QblDropInvalidURL;
 
 public class ContactExportImport {
 
-    private static final String KEY_ALIAS = "QABELALIAS";
-    private static final String KEY_DROP_URLS = "QABELDROPURL";
-    private static final String KEY_KEY_IDENTIFIER = "QABELKEYIDENTIFIER";
+	private static final String KEY_ALIAS = "alias";
+	private static final String KEY_EMAIL = "email";
+	private static final String KEY_PHONE = "phone";
+	private static final String KEY_PUBLIC_KEY = "public_key";
+	private static final String KEY_DROP_URLS = "dropURLs";
+	private static final String KEY_CONTACTS = "contacts";
 
-    /**
+
+	public static String exportContacts(Contacts contacts) throws JSONException {
+		JSONObject jsonObject = new JSONObject();
+		JSONArray jsonContacts = new JSONArray();
+		for (Contact contact : contacts.getContacts()) {
+			jsonContacts.put(getJSONfromContact(contact));
+		}
+		jsonObject.put(KEY_CONTACTS, jsonContacts);
+		return jsonObject.toString();
+	}
+
+	public static String exportContact(Contact contact) {
+		return getJSONfromContact(contact).toString();
+	}
+
+	private static JSONObject getJSONfromContact(Contact contact) {
+		JSONObject jsonObject = new JSONObject();
+		JSONArray jsonDropUrls = new JSONArray();
+		try {
+			jsonObject.put(KEY_ALIAS, contact.getAlias());
+			jsonObject.put(KEY_EMAIL, contact.getEmail());
+			jsonObject.put(KEY_PHONE, contact.getPhone());
+			jsonObject.put(KEY_PUBLIC_KEY, contact.getKeyIdentifier());
+			for (DropURL dropURL : contact.getDropUrls()) {
+				jsonDropUrls.put(dropURL);
+			}
+			jsonObject.put(KEY_DROP_URLS, jsonDropUrls);
+		} catch (JSONException e) {
+			// Shouldn't be possible to trigger this exception
+			throw new RuntimeException("Cannot build JSONObject", e);
+		}
+		return jsonObject;
+	}
+
+	/**
      * Exports the {@link Contact} information as a JSON string from an {@link Identity}
      * @param identity {@link Identity} to export {@link Contact} information from
      * @return {@link Contact} information as JSON string
@@ -32,11 +72,13 @@ public class ContactExportImport {
         JSONArray jsonDropUrls = new JSONArray();
         try {
             jsonObject.put(KEY_ALIAS, identity.getAlias());
+			jsonObject.put(KEY_EMAIL, identity.getEmail());
+			jsonObject.put(KEY_PHONE, identity.getPhone());
+			jsonObject.put(KEY_PUBLIC_KEY, identity.getKeyIdentifier());
             for (DropURL dropURL : identity.getDropUrls()) {
                 jsonDropUrls.put(dropURL);
             }
             jsonObject.put(KEY_DROP_URLS, jsonDropUrls);
-            jsonObject.put(KEY_KEY_IDENTIFIER, identity.getKeyIdentifier());
         } catch (JSONException e) {
             // Shouldn't be possible to trigger this exception
             throw new RuntimeException("Cannot build JSONObject", e);
@@ -55,7 +97,31 @@ public class ContactExportImport {
      * @throws QblDropInvalidURL
      */
     public static Contact parseContactForIdentity(Identity identity, String json) throws JSONException, URISyntaxException, QblDropInvalidURL {
-        JSONObject jsonObject = new JSONObject(json);
+		return parseContactFromJSON(identity, json);
+	}
+
+	/**
+	 * Parse {@link Contacts} from a {@link Contacts} JSON string
+	 * @param identity {@link Identity} for setting the owner of the {@link Contact}s
+	 * @param json {@link Contacts} JSON string
+	 * @return {@link Contacts} parsed from JSON string
+	 * @throws JSONException
+	 * @throws URISyntaxException
+	 * @throws QblDropInvalidURL
+	 */
+	public static Contacts parseContactsForIdentity(Identity identity, String json) throws JSONException, URISyntaxException, QblDropInvalidURL {
+		Contacts contacts = new Contacts();
+		JSONObject jsonObject = new JSONObject(json);
+		JSONArray jsonContacts = jsonObject.getJSONArray(KEY_CONTACTS);
+		for (int i = 0; i < jsonContacts.length(); i++) {
+			contacts.put(parseContactFromJSON(identity, jsonContacts.getString(i)));
+		}
+		return contacts;
+	}
+
+	@NonNull
+	private static Contact parseContactFromJSON(Identity identity, String json) throws JSONException, URISyntaxException, QblDropInvalidURL {
+		JSONObject jsonObject = new JSONObject(json);
 
         Collection<DropURL> dropURLs = new ArrayList<>();
         String alias = jsonObject.getString(KEY_ALIAS);
@@ -63,8 +129,15 @@ public class ContactExportImport {
         for (int i = 0; i < jsonDropURLS.length(); i++) {
             dropURLs.add(new DropURL(jsonDropURLS.getString(i)));
         }
-        String keyIdentifier = jsonObject.getString(KEY_KEY_IDENTIFIER);
+		String keyIdentifier = jsonObject.getString(KEY_PUBLIC_KEY);
 
-        return new Contact(identity, alias, dropURLs, new QblECPublicKey(Hex.decode(keyIdentifier)));
-    }
+		Contact contact = new Contact(identity, alias, dropURLs, new QblECPublicKey(Hex.decode(keyIdentifier)));
+		if (jsonObject.has(KEY_EMAIL)) {
+			contact.setEmail(jsonObject.getString(KEY_EMAIL));
+		}
+		if (jsonObject.has(KEY_PHONE)) {
+			contact.setPhone(jsonObject.getString(KEY_PHONE));
+		}
+		return contact;
+	}
 }

--- a/qabelbox/src/main/res/values/strings.xml
+++ b/qabelbox/src/main/res/values/strings.xml
@@ -158,4 +158,5 @@
     <string name="cant_read_identity">Can\'t read identity from file</string>
     <string name="identity_export_failed">Identity export failed!</string>
     <string name="identity_export_complete">Identity exported</string>
+    <string name="cant_read_contact">Cannot read contact!</string>
 </resources>


### PR DESCRIPTION
Public keys are exported as a hex string, because that is how we always intended to use key identifiers (as seen in Contacts ```getReadableKeyIdentifier()``` method).

Also the ```Contacts``` class containing multiple contacts can now be exported and imported.

This PR is related to #34, as is provides the back-end functionality for UI work from @dannywerner.