### PR TITLE
Single file share backend

### DIFF
--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/BoxTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/BoxTest.java
@@ -183,6 +183,26 @@ public class BoxTest extends AndroidTestCase {
 	}
 
 	@Test
+	public void testFileIsShared() throws QblStorageException, IOException {
+		BoxNavigation nav = volume.navigate();
+		File file = new File(testFileName);
+		BoxFile boxFile = nav.upload("foobar", new FileInputStream(file), null);
+		nav.commit();
+
+		assertThat(boxFile.isShared(), is(false));
+
+		nav.createFileMetadata(OWNER, boxFile);
+		nav.commit();
+
+		assertThat(boxFile.isShared(), is(true));
+
+		nav.removeFileMetadata(boxFile);
+		nav.commit();
+
+		assertThat(boxFile.isShared(), is(false));
+	}
+
+	@Test
 	public void testDetachFileMetadataShareFile() throws QblStorageException, IOException {
 		BoxNavigation nav = volume.navigate();
 		File file = new File(testFileName);

--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/BoxTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/BoxTest.java
@@ -47,8 +47,9 @@ import static org.junit.Assert.assertThat;
 
 public class BoxTest extends AndroidTestCase {
     private static final Logger logger = LoggerFactory.getLogger(BoxTest.class.getName());
+	private static final String OWNER = "owner";
 
-    BoxVolume volume;
+	BoxVolume volume;
     BoxVolume volume2;
 	BoxVolume volumeOtherUser;
     byte[] deviceID;
@@ -161,23 +162,24 @@ public class BoxTest extends AndroidTestCase {
 		BoxFile boxFile = nav.upload("foobar", new FileInputStream(file), null);
 		nav.commit();
 
-		nav.createFileMetadata(boxFile);
+		nav.createFileMetadata(OWNER, boxFile);
 		nav.commit();
 
 		// Share meta and metakey to other user
 
 		BoxNavigation navOtherUser = volumeOtherUser.navigate();
-		navOtherUser.attachExternalFile(boxFile.meta, boxFile.metakey);
+		navOtherUser.attachExternalFile(OWNER, boxFile.meta, boxFile.metakey);
 		navOtherUser.commit();
 
-		List<BoxFile> boxFiles = navOtherUser.listFiles();
-		assertThat(boxFiles.size(), is(1));
-		BoxFile boxFileReceived = boxFiles.get(0);
-		assertThat(boxFileReceived.block, is(equalTo(boxFile.block)));
-		assertThat(boxFileReceived.name, is(equalTo(boxFile.name)));
-		assertThat(boxFileReceived.key, is(equalTo(boxFile.key)));
-		assertThat(boxFileReceived.mtime, is(equalTo(boxFile.mtime)));
-		assertThat(boxFileReceived.size, is(equalTo(boxFile.size)));
+		List<BoxExternalFile> boxExternalFiles = navOtherUser.listExternalFiles();
+		assertThat(boxExternalFiles.size(), is(1));
+		BoxExternalFile boxFileReceived = boxExternalFiles.get(0);
+		assertThat(boxFile.block, is(equalTo(boxFileReceived.block)));
+		assertThat(boxFile.name, is(equalTo(boxFileReceived.name)));
+		assertThat(boxFile.size, is(equalTo(boxFileReceived.size)));
+		assertThat(boxFile.mtime, is(equalTo(boxFileReceived.mtime)));
+		assertThat(boxFile.key, is(equalTo(boxFileReceived.key)));
+		assertThat(OWNER, is(equalTo(boxFileReceived.owner)));
 	}
 
 	@Test
@@ -187,23 +189,23 @@ public class BoxTest extends AndroidTestCase {
 		BoxFile boxFile = nav.upload("foobar", new FileInputStream(file), null);
 		nav.commit();
 
-		nav.createFileMetadata(boxFile);
+		nav.createFileMetadata(OWNER, boxFile);
 		nav.commit();
 
 		// Share meta and metakey to other user
 
 		BoxNavigation navOtherUser = volumeOtherUser.navigate();
-		navOtherUser.attachExternalFile(boxFile.meta, boxFile.metakey);
+		navOtherUser.attachExternalFile(OWNER, boxFile.meta, boxFile.metakey);
 		navOtherUser.commit();
 
-		List<BoxFile> boxFiles = navOtherUser.listFiles();
-		assertThat(boxFiles.size(), is(1));
+		List<BoxExternalFile> boxExternalFiles = navOtherUser.listExternalFiles();
+		assertThat(boxExternalFiles.size(), is(1));
 
-		navOtherUser.detachExternalFile(boxFiles.get(0));
+		navOtherUser.detachExternalFile(boxExternalFiles.get(0));
 		navOtherUser.commit();
 
-		boxFiles = navOtherUser.listFiles();
-		assertThat(boxFiles.size(), is(0));
+		boxExternalFiles = navOtherUser.listExternalFiles();
+		assertThat(boxExternalFiles.size(), is(0));
 	}
 
 	@Test

--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/DirectoryMetadataTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/DirectoryMetadataTest.java
@@ -47,7 +47,7 @@ public class DirectoryMetadataTest extends TestCase{
 
 	@Test
 	public void testFileOperations() throws QblStorageException {
-		BoxFile file = new BoxFile("block", "name", 0L, 0L, new byte[] {1,2,});
+		BoxFile file = new BoxFile("block", "name", 0L, 0L, new byte[] {1,2,}, "metablock", new byte[]{0x03, 0x04});
 		dm.insertFile(file);
 		assertThat(dm.listFiles().size(), is(1));
 		assertThat(file, equalTo(dm.listFiles().get(0)));

--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/FileMetadataTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/FileMetadataTest.java
@@ -27,13 +27,24 @@ public class FileMetadataTest {
 
 	@Test
 	public void testFileMetadataBoxFile() throws QblStorageException {
-		assertThat(fileMetadata.getFile(), is(equalTo(boxFile)));
+		BoxExternalFile boxFileFromMetadata = fileMetadata.getFile();
+		assertThat(boxFile.block, is(equalTo(boxFileFromMetadata.block)));
+		assertThat(boxFile.name, is(equalTo(boxFileFromMetadata.name)));
+		assertThat(boxFile.size, is(equalTo(boxFileFromMetadata.size)));
+		assertThat(boxFile.mtime, is(equalTo(boxFileFromMetadata.mtime)));
+		assertThat(boxFile.key, is(equalTo(boxFileFromMetadata.key)));
 	}
 
 	@Test
 	public void testRecreateFileMetadataFromFile() throws QblStorageException, IOException {
 		FileMetadata fileMetadataFromTemp = new FileMetadata(fileMetadata.getPath());
-		assertThat(fileMetadataFromTemp.getFile(), is(equalTo(boxFile)));
+		BoxExternalFile boxFileFromMetadata = fileMetadataFromTemp.getFile();
+		assertThat(boxFile.block, is(equalTo(boxFileFromMetadata.block)));
+		assertThat(boxFile.name, is(equalTo(boxFileFromMetadata.name)));
+		assertThat(boxFile.size, is(equalTo(boxFileFromMetadata.size)));
+		assertThat(boxFile.mtime, is(equalTo(boxFileFromMetadata.mtime)));
+		assertThat(boxFile.key, is(equalTo(boxFileFromMetadata.key)));
+		assertThat(OWNER, is(equalTo(boxFileFromMetadata.owner)));
 	}
 
 	@Test

--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/FileMetadataTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/FileMetadataTest.java
@@ -14,13 +14,15 @@ import static org.junit.Assert.*;
 
 public class FileMetadataTest {
 
+	private static final String OWNER = "owner";
+
 	private BoxFile boxFile;
 	private FileMetadata fileMetadata;
 
 	@Before
 	public void setUp() throws Exception {
 		boxFile = new BoxFile("Block", "Name", 1000L, 1000L, new byte[]{0x00, 0x01, 0x02});
-		fileMetadata = new FileMetadata(boxFile, new File(System.getProperty("java.io.tmpdir")));
+		fileMetadata = new FileMetadata(OWNER, boxFile, new File(System.getProperty("java.io.tmpdir")));
 	}
 
 	@Test

--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/FileMetadataTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/FileMetadataTest.java
@@ -1,0 +1,41 @@
+package de.qabel.qabelbox.storage;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import de.qabel.qabelbox.exceptions.QblStorageException;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+public class FileMetadataTest {
+
+	private BoxFile boxFile;
+	private FileMetadata fileMetadata;
+
+	@Before
+	public void setUp() throws Exception {
+		boxFile = new BoxFile("Block", "Name", 1000L, 1000L, new byte[]{0x00, 0x01, 0x02});
+		fileMetadata = new FileMetadata(boxFile, new File(System.getProperty("java.io.tmpdir")));
+	}
+
+	@Test
+	public void testFileMetadataBoxFile() throws QblStorageException {
+		assertThat(fileMetadata.getFile(), is(equalTo(boxFile)));
+	}
+
+	@Test
+	public void testRecreateFileMetadataFromFile() throws QblStorageException, IOException {
+		FileMetadata fileMetadataFromTemp = new FileMetadata(fileMetadata.getPath());
+		assertThat(fileMetadataFromTemp.getFile(), is(equalTo(boxFile)));
+	}
+
+	@Test
+	public void testSpecVersion() throws QblStorageException {
+		assertThat(fileMetadata.getSpecVersion(), is(0));
+	}
+}

--- a/qabelbox/src/main/java/de/qabel/qabelbox/exceptions/QblStorageException.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/exceptions/QblStorageException.java
@@ -10,4 +10,8 @@ public class QblStorageException extends QblException {
 	public QblStorageException(String s) {
 		super(s);
 	}
+
+	public QblStorageException(String s, Throwable e) {
+		super(s, e);
+	}
 }

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxExternalFile.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxExternalFile.java
@@ -1,0 +1,30 @@
+package de.qabel.qabelbox.storage;
+
+public class BoxExternalFile extends BoxFile {
+
+	public String owner;
+
+	public BoxExternalFile(String owner, String block, String name, Long size, Long mtime, byte[] key) {
+		super(block, name, size, mtime, key);
+		this.owner = owner;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		if (!super.equals(o)) return false;
+
+		BoxExternalFile that = (BoxExternalFile) o;
+
+		return !(owner != null ? !owner.equals(that.owner) : that.owner != null);
+
+	}
+
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (owner != null ? owner.hashCode() : 0);
+		return result;
+	}
+}

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxFile.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxFile.java
@@ -60,4 +60,16 @@ public class BoxFile extends BoxObject {
 	protected BoxFile clone() throws CloneNotSupportedException {
 		return new BoxFile(block,name,size,mtime, key, meta,metakey);
 	}
+
+	/**
+	 * Get if BoxFile is shared. Tests only if meta and metakey is not null, not if a share has been
+	 * successfully send to another user.
+	 * @return True if BoxFile might be shared.
+	 */
+	public boolean isShared() {
+		if (meta != null && metakey != null) {
+			return true;
+		}
+		return false;
+	}
 }

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxFile.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxFile.java
@@ -7,6 +7,8 @@ public class BoxFile extends BoxObject {
 	public Long size;
 	public Long mtime;
 	public byte[] key;
+	public String meta;
+	public byte[] metakey;
 
 	@Override
 	public boolean equals(Object o) {
@@ -19,8 +21,9 @@ public class BoxFile extends BoxObject {
 		if (name != null ? !name.equals(boxFile.name) : boxFile.name != null) return false;
 		if (size != null ? !size.equals(boxFile.size) : boxFile.size != null) return false;
 		if (mtime != null ? !mtime.equals(boxFile.mtime) : boxFile.mtime != null) return false;
-		return Arrays.equals(key, boxFile.key);
-
+		if (!Arrays.equals(key, boxFile.key)) return false;
+		if (meta != null ? !meta.equals(boxFile.meta) : boxFile.meta != null) return false;
+		return Arrays.equals(metakey, boxFile.metakey);
 	}
 
 	@Override
@@ -30,6 +33,8 @@ public class BoxFile extends BoxObject {
 		result = 31 * result + (size != null ? size.hashCode() : 0);
 		result = 31 * result + (mtime != null ? mtime.hashCode() : 0);
 		result = 31 * result + (key != null ? Arrays.hashCode(key) : 0);
+		result = 31 * result + (meta != null ? meta.hashCode() : 0);
+		result = 31 * result + (metakey != null ? Arrays.hashCode(metakey) : 0);
 		return result;
 	}
 
@@ -41,8 +46,18 @@ public class BoxFile extends BoxObject {
 		this.key = key;
 	}
 
+	public BoxFile(String block, String name, Long size, Long mtime, byte[] key, String meta, byte[] metaKey) {
+		super(name);
+		this.block = block;
+		this.size = size;
+		this.mtime = mtime;
+		this.meta = meta;
+		this.metakey = metaKey;
+		this.key = key;
+	}
+
 	@Override
 	protected BoxFile clone() throws CloneNotSupportedException {
-		return new BoxFile(block,name,size,mtime,key);
+		return new BoxFile(block,name,size,mtime, key, meta,metakey);
 	}
 }

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxNavigation.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxNavigation.java
@@ -3,6 +3,7 @@ package de.qabel.qabelbox.storage;
 import android.support.annotation.Nullable;
 
 import de.qabel.qabelbox.exceptions.QblStorageException;
+import de.qabel.qabelbox.exceptions.QblStorageNotFound;
 
 import java.io.InputStream;
 import java.util.List;
@@ -29,6 +30,12 @@ public interface BoxNavigation {
 
 	BoxFile upload(String name, InputStream content, @Nullable TransferManager.BoxTransferListener boxTransferListener) throws QblStorageException;
 	InputStream download(BoxFile file, @Nullable TransferManager.BoxTransferListener boxTransferListener) throws QblStorageException;
+
+	boolean createFileMetadata(BoxFile boxFile);
+	boolean removeFileMetadata(BoxFile boxFile);
+
+	void attachExternalFile(String metaURL, byte[] metaKey) throws QblStorageException;
+	void detachExternalFile(BoxFile boxFile) throws QblStorageException;
 
 	void delete(BoxObject boxObject) throws QblStorageException;
 	void delete(BoxFile boxFile) throws QblStorageException;

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxNavigation.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxNavigation.java
@@ -27,15 +27,16 @@ public interface BoxNavigation {
 	List<BoxFile> listFiles() throws QblStorageException;
 	List<BoxFolder> listFolders() throws QblStorageException;
 	List<BoxExternal> listExternals() throws QblStorageException;
+	List<BoxExternalFile> listExternalFiles() throws QblStorageException;
 
 	BoxFile upload(String name, InputStream content, @Nullable TransferManager.BoxTransferListener boxTransferListener) throws QblStorageException;
 	InputStream download(BoxFile file, @Nullable TransferManager.BoxTransferListener boxTransferListener) throws QblStorageException;
 
-	boolean createFileMetadata(BoxFile boxFile);
+	boolean createFileMetadata(String owner, BoxFile boxFile);
 	boolean removeFileMetadata(BoxFile boxFile);
 
-	void attachExternalFile(String metaURL, byte[] metaKey) throws QblStorageException;
-	void detachExternalFile(BoxFile boxFile) throws QblStorageException;
+	void attachExternalFile(String owner, String metaURL, byte[] metaKey) throws QblStorageException;
+	void detachExternalFile(BoxExternalFile boxExternalFile) throws QblStorageException;
 
 	void delete(BoxObject boxObject) throws QblStorageException;
 	void delete(BoxFile boxFile) throws QblStorageException;

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxVolume.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxVolume.java
@@ -55,7 +55,7 @@ public class BoxVolume {
 		AmazonS3Client awsClient = new AmazonS3Client(credentials);
 		this.rootId = new DocumentIdParser().buildId(
 				keyPair.getPub().getReadableKeyIdentifier(), bucket, prefix, null);
-		transferManager = new TransferManager(transferUtility, awsClient, bucket, prefix, tempDir);
+		transferManager = new TransferManager(transferUtility, awsClient, bucket, tempDir);
 		this.prefix = prefix;
 		this.bucket = bucket;
 	}
@@ -70,7 +70,7 @@ public class BoxVolume {
 
 	private InputStream blockingDownload(String name) throws QblStorageNotFound {
 		File tmp = transferManager.createTempFile();
-		int id = transferManager.download(name, tmp, null);
+		int id = transferManager.download(prefix, name, tmp, null);
 		if (transferManager.waitFor(id)) {
 			try {
 				return new FileInputStream(tmp);
@@ -90,7 +90,7 @@ public class BoxVolume {
 		} catch (IOException e) {
 			throw new QblStorageException(e);
 		}
-		int id = transferManager.upload(name, tmp, null);
+		int id = transferManager.upload(prefix, name, tmp, null);
 		if (!transferManager.waitFor(id)) {
 			throw new QblStorageException("Upload failed");
 		}
@@ -98,7 +98,7 @@ public class BoxVolume {
 
 
 	public BoxNavigation navigate() throws QblStorageException {
-		return new FolderNavigation(getDirectoryMetadata(), keyPair, null, deviceId, transferManager,
+		return new FolderNavigation(prefix, getDirectoryMetadata(), keyPair, null, deviceId, transferManager,
 				this, PATH_ROOT, null, context);
 	}
 

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/DirectoryMetadata.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/DirectoryMetadata.java
@@ -53,7 +53,9 @@ class DirectoryMetadata {
 					" name VARCHAR(255) NULL PRIMARY KEY," +
 					" size LONG NOT NULL," +
 					" mtime LONG NOT NULL," +
-					" key BLOB NOT NULL )",
+					" key BLOB NOT NULL, " +
+					" meta VARCHAR(255), " +
+					" metakey BLOB )",
 			"CREATE TABLE folders (" +
 					" ref VARCHAR(255)NOT NULL," +
 					" name VARCHAR(255)NOT NULL PRIMARY KEY," +
@@ -340,11 +342,11 @@ class DirectoryMetadata {
 		try {
 			statement = connection.createStatement();
 			ResultSet rs = statement.executeQuery(
-					"SELECT block, name, size, mtime, key FROM files");
+					"SELECT block, name, size, mtime, key, meta, metakey FROM files");
 			List<BoxFile> files = new ArrayList<>();
 			while (rs.next()) {
 				files.add(new BoxFile(rs.getString(1),
-						rs.getString(2), rs.getLong(3), rs.getLong(4), rs.getBytes(5)));
+						rs.getString(2), rs.getLong(3), rs.getLong(4), rs.getBytes(5), rs.getString(6), rs.getBytes(7)));
 			}
 			return files;
 		} catch (SQLException e) {
@@ -369,12 +371,14 @@ class DirectoryMetadata {
 		PreparedStatement st = null;
 		try {
 			st = connection.prepareStatement(
-					"INSERT INTO files (block, name, size, mtime, key) VALUES(?, ?, ?, ?, ?)");
+					"INSERT INTO files (block, name, size, mtime, key, meta, metakey) VALUES(?, ?, ?, ?, ?, ?, ?)");
 			st.setString(1, file.block);
 			st.setString(2, file.name);
 			st.setLong(3, file.size);
 			st.setLong(4, file.mtime);
 			st.setBytes(5, file.key);
+			st.setString(6, file.meta);
+			st.setBytes(7, file.metakey);
 			if (st.executeUpdate() != 1) {
 				throw new QblStorageException("Failed to insert file");
 			}
@@ -550,12 +554,12 @@ class DirectoryMetadata {
 		PreparedStatement statement = null;
 		try {
 			statement = connection.prepareStatement(
-					"SELECT block, name, size, mtime, key FROM files WHERE name=?");
+					"SELECT block, name, size, mtime, key, meta, metakey FROM files WHERE name=?");
 			statement.setString(1, name);
 			ResultSet rs = statement.executeQuery();
 			if (rs.next()) {
 				return new BoxFile(rs.getString(1),
-						rs.getString(2), rs.getLong(3), rs.getLong(4), rs.getBytes(5));
+						rs.getString(2), rs.getLong(3), rs.getLong(4), rs.getBytes(5), rs.getString(6), rs.getBytes(7));
 			}
 			return null;
 		} catch (SQLException e) {

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/FileMetadata.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/FileMetadata.java
@@ -1,0 +1,130 @@
+package de.qabel.qabelbox.storage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import de.qabel.qabelbox.exceptions.QblStorageException;
+
+class FileMetadata {
+	private static final Logger logger = LoggerFactory.getLogger(FileMetadata.class.getName());
+	private static final String JDBC_PREFIX = "jdbc:sqlite:";
+	private static final String JDBC_CLASS = "org.sqldroid.SQLDroidDriver";
+	private final Connection connection;
+
+	private final File path;
+
+	private final String[] initSql = {
+			"CREATE TABLE spec_version (" +
+					" version INTEGER PRIMARY KEY )",
+			"CREATE TABLE file (" +
+					" block VARCHAR(255) NOT NULL," +
+					" name VARCHAR(255) NULL PRIMARY KEY," +
+					" size LONG NOT NULL," +
+					" mtime LONG NOT NULL," +
+					" key BLOB NOT NULL )",
+			"INSERT INTO spec_version (version) VALUES(0)"
+	};
+
+	public FileMetadata(BoxFile boxFile, File tempDir) throws QblStorageException {
+		try {
+			path = File.createTempFile("dir", "db", tempDir);
+		} catch (IOException e) {
+			throw new QblStorageException(e);
+		}
+		try {
+			Class.forName(JDBC_CLASS);
+			connection = DriverManager.getConnection(JDBC_PREFIX + path.getAbsolutePath());
+			connection.setAutoCommit(true);
+		} catch (SQLException e) {
+			throw new RuntimeException("Cannot open database!", e);
+		} catch (ClassNotFoundException e) {
+			throw new QblStorageException(e);
+		}
+		try {
+			initDatabase();
+		} catch (SQLException e) {
+			throw new RuntimeException("Cannot init the database", e);
+		}
+		insertFile(boxFile);
+	}
+
+	public FileMetadata(File path) throws QblStorageException {
+		this.path = path;
+		try {
+			Class.forName(JDBC_CLASS);
+			connection = DriverManager.getConnection(JDBC_PREFIX + path.getAbsolutePath());
+			connection.setAutoCommit(true);
+		} catch (SQLException e) {
+			throw new RuntimeException("Cannot open database!", e);
+		} catch (ClassNotFoundException e) {
+			throw new QblStorageException(e);
+		}
+	}
+
+	private void insertFile(BoxFile boxFile) throws QblStorageException {
+		try (PreparedStatement statement = connection.prepareStatement(
+					"INSERT INTO file (block, name, size, mtime, key) VALUES(?, ?, ?, ?, ?)")) {
+			statement.setString(1, boxFile.block);
+			statement.setString(2, boxFile.name);
+			statement.setLong(3, boxFile.size);
+			statement.setLong(4, boxFile.mtime);
+			statement.setBytes(5, boxFile.key);
+			if (statement.executeUpdate() != 1) {
+				throw new QblStorageException("Failed to insert file");
+			}
+
+		} catch (SQLException e) {
+			logger.error("Could not insert file " + boxFile.name);
+			throw new QblStorageException(e);
+		}
+	}
+
+	public File getPath() {
+		return path;
+	}
+
+	private void initDatabase() throws SQLException, QblStorageException {
+		for (String q : initSql) {
+			try (Statement statement = connection.createStatement()){
+				statement.executeUpdate(q);
+			}
+		}
+	}
+
+	Integer getSpecVersion() throws QblStorageException {
+		try (Statement statement = connection.createStatement()) {
+			ResultSet rs = statement.executeQuery(
+					"SELECT version FROM spec_version");
+			if (rs.next()) {
+				return rs.getInt(1);
+			} else {
+				throw new QblStorageException("No version found!");
+			}
+		} catch (SQLException e) {
+			throw new QblStorageException(e);
+		}
+	}
+
+	BoxFile getFile() throws QblStorageException {
+		try (Statement statement = connection.createStatement()) {
+			ResultSet rs = statement.executeQuery("SELECT block, name, size, mtime, key FROM file LIMIT 1");
+			if (rs.next()) {
+				return new BoxFile(rs.getString(1),
+						rs.getString(2), rs.getLong(3), rs.getLong(4), rs.getBytes(5));
+			}
+			return null;
+		} catch (SQLException e) {
+			throw new QblStorageException(e);
+		}
+	}
+}
+

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/FolderNavigation.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/FolderNavigation.java
@@ -28,10 +28,10 @@ public class FolderNavigation extends AbstractNavigation {
 
 	private static final Logger logger = LoggerFactory.getLogger(FolderNavigation.class.getName());
 
-	public FolderNavigation(DirectoryMetadata dm, QblECKeyPair keyPair, @Nullable byte[] dmKey, byte[] deviceId,
+	public FolderNavigation(String prefix, DirectoryMetadata dm, QblECKeyPair keyPair, @Nullable byte[] dmKey, byte[] deviceId,
 	                        TransferManager transferUtility, BoxVolume boxVolume, String path,
 							@Nullable Stack<BoxFolder> parents, Context context) {
-		super(dm, keyPair, dmKey, deviceId, transferUtility, boxVolume, path, parents, context);
+		super(prefix, dm, keyPair, dmKey, deviceId, transferUtility, boxVolume, path, parents, context);
 	}
 
 	@Override
@@ -52,7 +52,7 @@ public class FolderNavigation extends AbstractNavigation {
 			FileOutputStream fileOutputStream = new FileOutputStream(tmp);
 			fileOutputStream.write(encrypted);
 			fileOutputStream.close();
-			blockingUpload(dm.getFileName(), tmp, null);
+			blockingUpload(prefix, dm.getFileName(), tmp, null);
 		} catch (IOException | InvalidKeyException e) {
 			throw new QblStorageException(e);
 		}
@@ -61,7 +61,7 @@ public class FolderNavigation extends AbstractNavigation {
 	private void uploadDirectoryMetadataSubFolder() throws QblStorageException {
 		logger.info("Uploading directory metadata");
 		try {
-			uploadEncrypted(new FileInputStream(dm.getPath()), new KeyParameter(dmKey),
+			uploadEncrypted(new FileInputStream(dm.getPath()), new KeyParameter(dmKey), prefix,
 					dm.getFileName(), null);
 		} catch (FileNotFoundException e) {
 			throw new QblStorageException(e);
@@ -81,7 +81,7 @@ public class FolderNavigation extends AbstractNavigation {
 		logger.info("Reloading directory metadata");
 		// duplicate of navigate()
 		try {
-			File indexDl = blockingDownload(dm.getFileName(), null);
+			File indexDl = blockingDownload(prefix, dm.getFileName(), null);
 			File tmp = File.createTempFile("dir", "db", dm.getTempDir());
 			if (cryptoUtils.decryptFileAuthenticatedSymmetricAndValidateTag(
 					new FileInputStream(indexDl), tmp, new KeyParameter(dmKey))) {
@@ -97,7 +97,7 @@ public class FolderNavigation extends AbstractNavigation {
 	protected DirectoryMetadata reloadMetadataRoot() throws QblStorageException {
 		// TODO: duplicate with BoxVoume.navigate()
 		String rootRef = dm.getFileName();
-		File indexDl = blockingDownload(rootRef, null);
+		File indexDl = blockingDownload(prefix, rootRef, null);
 		File tmp;
 		try {
 			byte[] encrypted = IOUtils.toByteArray(new FileInputStream(indexDl));


### PR DESCRIPTION
Backend for #29 and #51

Two additions to the current spec has been made, ~~a PR for the spec will follow.~~ (Owner in FileMetadata and externalFiles table in DirectoryMetadata).

* Allows to create a DirectoryMetadata file from a BoxFile and add the reference and key to the BoxFile. 
* Allows to attach and detach a received reference to a shared BoxFile (FileMetadata) into the DirectoryMetadata.

Edit: Spec PR: https://github.com/Qabel/qabel.github.io/pull/146