### PR TITLE
Follow up to single file share

### DIFF
--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/BoxTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/BoxTest.java
@@ -37,6 +37,7 @@ import java.util.UUID;
 
 import de.qabel.core.crypto.CryptoUtils;
 import de.qabel.core.crypto.QblECKeyPair;
+import de.qabel.core.crypto.QblECPublicKey;
 import de.qabel.qabelbox.R;
 import de.qabel.qabelbox.exceptions.QblStorageException;
 import de.qabel.qabelbox.exceptions.QblStorageNameConflict;
@@ -47,7 +48,7 @@ import static org.junit.Assert.assertThat;
 
 public class BoxTest extends AndroidTestCase {
     private static final Logger logger = LoggerFactory.getLogger(BoxTest.class.getName());
-	private static final String OWNER = "owner";
+	private static final QblECPublicKey OWNER = new QblECKeyPair().getPub();
 
 	BoxVolume volume;
     BoxVolume volume2;

--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/BoxTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/BoxTest.java
@@ -126,19 +126,24 @@ public class BoxTest extends AndroidTestCase {
     }
 
     public void tearDown() throws IOException {
-        ObjectListing listing = s3Client.listObjects(bucket, prefix);
-        List<DeleteObjectsRequest.KeyVersion> keys = new ArrayList<>();
-        for (S3ObjectSummary summary : listing.getObjectSummaries()) {
-            logger.info("deleting key" + summary.getKey());
-            keys.add(new DeleteObjectsRequest.KeyVersion(summary.getKey()));
-        }
-        if (keys.isEmpty()) {
-            return;
-        }
-        DeleteObjectsRequest deleteObjectsRequest = new DeleteObjectsRequest(bucket);
-        deleteObjectsRequest.setKeys(keys);
-        s3Client.deleteObjects(deleteObjectsRequest);
+		deleteObjects(bucket, prefix);
+		deleteObjects(bucket, prefixOtherUser);
     }
+
+	private void deleteObjects(String bucket, String prefix) {
+		ObjectListing listing = s3Client.listObjects(bucket, prefix);
+		List<DeleteObjectsRequest.KeyVersion> keys = new ArrayList<>();
+		for (S3ObjectSummary summary : listing.getObjectSummaries()) {
+			logger.info("deleting key" + summary.getKey());
+			keys.add(new DeleteObjectsRequest.KeyVersion(summary.getKey()));
+		}
+		if (keys.isEmpty()) {
+			return;
+		}
+		DeleteObjectsRequest deleteObjectsRequest = new DeleteObjectsRequest(bucket);
+		deleteObjectsRequest.setKeys(keys);
+
+	}
 
     @Test
     public void testCreateIndex() throws QblStorageException {

--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/BoxTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/BoxTest.java
@@ -260,7 +260,10 @@ public class BoxTest extends AndroidTestCase {
 		// Check that updated file cannot be read anymore
 
 		boxExternalFiles = navOtherUser.listExternals();
-		assertThat(boxExternalFiles.size(), is(0));
+		assertThat(boxExternalFiles.size(), is(1));
+		assertTrue(boxExternalFiles.get(0) instanceof BoxExternalFile);
+		boxFileReceived = (BoxExternalFile) boxExternalFiles.get(0);
+		assertThat(boxFileReceived.isAccessible(), is(false));
 	}
 
 	@Test

--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/DirectoryMetadataTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/DirectoryMetadataTest.java
@@ -4,10 +4,6 @@ import junit.framework.TestCase;
 
 import de.qabel.core.crypto.QblECKeyPair;
 import de.qabel.qabelbox.exceptions.QblStorageException;
-import de.qabel.qabelbox.storage.BoxExternal;
-import de.qabel.qabelbox.storage.BoxFile;
-import de.qabel.qabelbox.storage.BoxFolder;
-import de.qabel.qabelbox.storage.DirectoryMetadata;
 
 import org.junit.Test;
 
@@ -39,7 +35,7 @@ public class DirectoryMetadataTest extends TestCase{
 		byte[] version = dm.getVersion();
 		assertThat(dm.listFiles().size(), is(0));
 		assertThat(dm.listFolders().size(), is(0));
-		assertThat(dm.listExternals().size(), is(0));
+		assertThat(dm.listExternalReferences().size(), is(0));
 		dm.commit();
 		assertThat(dm.getVersion(), is(not(equalTo(version))));
 
@@ -68,13 +64,13 @@ public class DirectoryMetadataTest extends TestCase{
 
 	@Test
 	public void testExternalOperations() throws QblStorageException {
-		BoxExternal external = new BoxExternal("https://foobar", "name",
+		BoxExternalReference external = new BoxExternalReference(false, "https://foobar", "name",
 				new QblECKeyPair().getPub(), new byte[] {1,2,});
-		dm.insertExternal(external);
-		assertThat(dm.listExternals().size(), is(1));
-		assertThat(external, equalTo(dm.listExternals().get(0)));
-		dm.deleteExternal(external);
-		assertThat(dm.listExternals().size(), is(0));
+		dm.insertExternalReference(external);
+		assertThat(dm.listExternalReferences().size(), is(1));
+		assertThat(external, equalTo(dm.listExternalReferences().get(0)));
+		dm.deleteExternalReference(external.name);
+		assertThat(dm.listExternalReferences().size(), is(0));
 	}
 
 	@Test

--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/FileMetadataTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/FileMetadataTest.java
@@ -6,6 +6,8 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 
+import de.qabel.core.crypto.QblECKeyPair;
+import de.qabel.core.crypto.QblECPublicKey;
 import de.qabel.qabelbox.exceptions.QblStorageException;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -14,7 +16,7 @@ import static org.junit.Assert.*;
 
 public class FileMetadataTest {
 
-	private static final String OWNER = "owner";
+	private static final QblECPublicKey OWNER = new QblECKeyPair().getPub();
 
 	private BoxFile boxFile;
 	private FileMetadata fileMetadata;

--- a/qabelbox/src/main/java/de/qabel/qabelbox/adapter/FilesAdapter.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/adapter/FilesAdapter.java
@@ -17,7 +17,8 @@ import java.util.Date;
 import java.util.List;
 
 import de.qabel.qabelbox.R;
-import de.qabel.qabelbox.storage.BoxExternal;
+import de.qabel.qabelbox.storage.BoxExternalFile;
+import de.qabel.qabelbox.storage.BoxExternalReference;
 import de.qabel.qabelbox.storage.BoxFile;
 import de.qabel.qabelbox.storage.BoxFolder;
 import de.qabel.qabelbox.storage.BoxObject;
@@ -112,9 +113,9 @@ public class FilesAdapter extends RecyclerView.Adapter<FilesAdapter.FilesViewHol
             holder.mTextViewFolderDetailsLeft.setText("");
             holder.mTextViewFolderDetailsRight.setText("");
 			holder.mProgressBar.setVisibility(View.INVISIBLE);
-        } else if (boxObject instanceof BoxExternal) {
-            BoxExternal boxExternal = (BoxExternal) boxObject;
-            holder.mImageView.setImageResource(R.drawable.ic_folder_shared_black);
+        } else if (boxObject instanceof BoxExternalFile) {
+            BoxExternalFile boxExternal = (BoxExternalFile) boxObject;
+            holder.mImageView.setImageResource(R.drawable.ic_insert_drive_file_black);
             // TODO: Only show a part of the key identifier until owner name is implemented
             holder.mTextViewFolderDetailsLeft.setText("Owner: " + boxExternal.owner.getReadableKeyIdentifier().substring(0, 6));
             holder.mTextViewFolderDetailsRight.setText("");

--- a/qabelbox/src/main/java/de/qabel/qabelbox/fragments/FilesFragment.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/fragments/FilesFragment.java
@@ -2,18 +2,14 @@ package de.qabel.qabelbox.fragments;
 
 import android.app.Activity;
 import android.content.BroadcastReceiver;
-import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.ServiceConnection;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.os.IBinder;
 import android.support.v4.content.LocalBroadcastManager;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.app.ActionBar;
-import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
@@ -39,7 +35,7 @@ import de.qabel.qabelbox.adapter.FilesAdapter;
 import de.qabel.qabelbox.exceptions.QblStorageException;
 import de.qabel.qabelbox.services.LocalBroadcastConstants;
 import de.qabel.qabelbox.services.LocalQabelService;
-import de.qabel.qabelbox.storage.BoxExternal;
+import de.qabel.qabelbox.storage.BoxExternalReference;
 import de.qabel.qabelbox.storage.BoxFile;
 import de.qabel.qabelbox.storage.BoxFolder;
 import de.qabel.qabelbox.storage.BoxNavigation;
@@ -554,7 +550,7 @@ public class FilesFragment extends BaseFragment {
                         Log.d(TAG, "Adding folder: " + boxFolder.name);
                         filesAdapter.add(boxFolder);
                     }
-                    for (BoxExternal boxExternal : boxNavigation.listExternals()) {
+                    for (BoxObject boxExternal : boxNavigation.listExternals()) {
                         Log.d("MainActivity", "Adding external: " + boxExternal.name);
                         filesAdapter.add(boxExternal);
                     }
@@ -681,7 +677,7 @@ public class FilesFragment extends BaseFragment {
                 Log.d(TAG, "Adding folder: " + boxFolder.name);
                 filesAdapter.add(boxFolder);
             }
-            for (BoxExternal boxExternal : boxNavigation.listExternals()) {
+            for (BoxObject boxExternal : boxNavigation.listExternals()) {
                 Log.d("MainActivity", "Adding external: " + boxExternal.name);
                 filesAdapter.add(boxExternal);
             }

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/AbstractNavigation.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/AbstractNavigation.java
@@ -317,8 +317,10 @@ public abstract class AbstractNavigation implements BoxNavigation {
 		// Overwrite = delete old file, upload new file
 		BoxFile oldFile = dm.getFile(name);
 		if (oldFile != null) {
-			boxFile.meta = oldFile.meta;
-			boxFile.metakey = oldFile.metakey.clone();
+			if (oldFile.meta != null && oldFile.metakey != null) {
+				boxFile.meta = oldFile.meta;
+				boxFile.metakey = oldFile.metakey.clone();
+			}
 			deleteQueue.add(oldFile.block);
 			dm.deleteFile(oldFile);
 		}

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/AbstractNavigation.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/AbstractNavigation.java
@@ -286,8 +286,16 @@ public abstract class AbstractNavigation implements BoxNavigation {
 					FileMetadata fileMetadata = new FileMetadata(out);
 					boxExternals.add(fileMetadata.getFile());
 				}
-			} catch (QblStorageException e) {
+			}
+			catch (QblStorageException e) {
 				Log.e(TAG, "Cannot load metadata file: " + boxExternalRefs.url);
+				if (boxExternalRefs.isFolder) {
+					boxExternals.add(new BoxExternalFolder(boxExternalRefs.url, boxExternalRefs.name,
+							boxExternalRefs.key, false));
+				} else {
+					boxExternals.add(new BoxExternalFile(boxExternalRefs.owner, boxExternalRefs.url,
+							boxExternalRefs.name, boxExternalRefs.key, false));
+				}
 			}
 		}
 		return boxExternals;

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/AbstractNavigation.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/AbstractNavigation.java
@@ -274,16 +274,20 @@ public abstract class AbstractNavigation implements BoxNavigation {
 		List<BoxObject> boxExternals = new ArrayList<>();
 		for (BoxExternalReference boxExternalRefs : dm.listExternalReferences()) {
 			String[] splitURL = boxExternalRefs.url.split("/");
-			File out = getMetadataFile(boxExternalRefs.url, boxExternalRefs.key);
-			if (boxExternalRefs.isFolder) {
-				//TODO: Check DirectoryMetadata handling
-				DirectoryMetadata directoryMetadata =
-						DirectoryMetadata.openDatabase(out, dm.deviceId, splitURL[1], dm.getTempDir());
-				boxExternals.addAll(directoryMetadata.listFiles());
-				boxExternals.addAll(directoryMetadata.listFolders());
-			} else {
-				FileMetadata fileMetadata = new FileMetadata(out);
-				boxExternals.add(fileMetadata.getFile());
+			try {
+				File out = getMetadataFile(boxExternalRefs.url, boxExternalRefs.key);
+				if (boxExternalRefs.isFolder) {
+					//TODO: Check DirectoryMetadata handling
+					DirectoryMetadata directoryMetadata =
+							DirectoryMetadata.openDatabase(out, dm.deviceId, splitURL[1], dm.getTempDir());
+					boxExternals.addAll(directoryMetadata.listFiles());
+					boxExternals.addAll(directoryMetadata.listFolders());
+				} else {
+					FileMetadata fileMetadata = new FileMetadata(out);
+					boxExternals.add(fileMetadata.getFile());
+				}
+			} catch (QblStorageException e) {
+				Log.e(TAG, "Cannot load metadata file: " + boxExternalRefs.url);
 			}
 		}
 		return boxExternals;

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/AbstractNavigation.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/AbstractNavigation.java
@@ -292,7 +292,7 @@ public abstract class AbstractNavigation implements BoxNavigation {
 	@NonNull
 	private File getMetadataFile(String url, byte[] key) throws QblStorageException {
 		String[] splitURL = url.split("/");
-		File encryptedMetadata = blockingDownload(splitURL[0], BLOCKS_PREFIX + splitURL[1], null);
+		File encryptedMetadata = blockingDownload(splitURL[0], splitURL[1], null);
 
 		File out = new File(context.getExternalCacheDir(), UUID.randomUUID().toString());
 
@@ -384,7 +384,7 @@ public abstract class AbstractNavigation implements BoxNavigation {
 		try {
 			FileMetadata fileMetadata = new FileMetadata(owner, boxFile, dm.getTempDir());
 			FileInputStream fileInputStream = new FileInputStream(fileMetadata.getPath());
-			uploadEncrypted(fileInputStream, key, prefix, BLOCKS_PREFIX + block, null);
+			uploadEncrypted(fileInputStream, key, prefix, block, null);
 
 			// Overwrite = delete old file, upload new file
 			BoxFile oldFile = dm.getFile(boxFile.name);
@@ -415,7 +415,7 @@ public abstract class AbstractNavigation implements BoxNavigation {
 			FileMetadata fileMetadataNew = new FileMetadata(fileMetadataOld.getFile().owner, boxFile, dm.getTempDir());
 			FileInputStream fileInputStream = new FileInputStream(fileMetadataNew.getPath());
 			String[] splitURL = boxFile.meta.split("/");
-			uploadEncrypted(fileInputStream, new KeyParameter(boxFile.metakey), splitURL[0], BLOCKS_PREFIX + splitURL[1], null);
+			uploadEncrypted(fileInputStream, new KeyParameter(boxFile.metakey), splitURL[0], splitURL[1], null);
 		} catch (QblStorageException | FileNotFoundException e) {
 			Log.e(TAG, "Could not create or upload FileMetadata", e);
 			return false;

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxExternal.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxExternal.java
@@ -2,45 +2,7 @@ package de.qabel.qabelbox.storage;
 
 import de.qabel.core.crypto.QblECPublicKey;
 
-import java.util.Arrays;
-
-public class BoxExternal extends BoxObject {
-	public String url;
-	public QblECPublicKey owner;
-	public byte[] key;
-
-	public BoxExternal(String url, String name, QblECPublicKey owner, byte[] key) {
-		super(name);
-		this.url = url;
-		this.owner = owner;
-		this.key = key;
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
-
-		BoxExternal that = (BoxExternal) o;
-
-		if (url != null ? !url.equals(that.url) : that.url != null) return false;
-		if (name != null ? !name.equals(that.name) : that.name != null) return false;
-		if (owner != null ? !owner.equals(that.owner) : that.owner != null) return false;
-		return Arrays.equals(key, that.key);
-
-	}
-
-	@Override
-	public int hashCode() {
-		int result = url != null ? url.hashCode() : 0;
-		result = 31 * result + (name != null ? name.hashCode() : 0);
-		result = 31 * result + (owner != null ? owner.hashCode() : 0);
-		result = 31 * result + (key != null ? Arrays.hashCode(key) : 0);
-		return result;
-	}
-
-	@Override
-	protected BoxExternal clone() throws CloneNotSupportedException {
-		return new BoxExternal(url,name,owner,key);
-	}
+public interface BoxExternal {
+	QblECPublicKey getOwner();
+	void setOwner(QblECPublicKey owner);
 }

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxExternal.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxExternal.java
@@ -5,4 +5,5 @@ import de.qabel.core.crypto.QblECPublicKey;
 public interface BoxExternal {
 	QblECPublicKey getOwner();
 	void setOwner(QblECPublicKey owner);
+	boolean isAccessible();
 }

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxExternalFile.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxExternalFile.java
@@ -5,10 +5,18 @@ import de.qabel.core.crypto.QblECPublicKey;
 public class BoxExternalFile extends BoxFile implements BoxExternal {
 
 	public QblECPublicKey owner;
+	private boolean isAccessible;
 
 	public BoxExternalFile(QblECPublicKey owner, String block, String name, Long size, Long mtime, byte[] key) {
 		super(block, name, size, mtime, key);
 		this.owner = owner;
+		this.isAccessible = true;
+	}
+
+	public BoxExternalFile(QblECPublicKey owner, String block, String name, byte[] key, boolean isAccessible) {
+		super(block, name, 0L, 0L, key);
+		this.owner = owner;
+		this.isAccessible = isAccessible;
 	}
 
 	@Override
@@ -38,5 +46,10 @@ public class BoxExternalFile extends BoxFile implements BoxExternal {
 	@Override
 	public void setOwner(QblECPublicKey owner) {
 		this.owner = owner;
+	}
+
+	@Override
+	public boolean isAccessible() {
+		return isAccessible;
 	}
 }

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxExternalFolder.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxExternalFolder.java
@@ -5,10 +5,12 @@ import de.qabel.core.crypto.QblECPublicKey;
 public class BoxExternalFolder extends BoxFolder implements BoxExternal {
 
 	public QblECPublicKey owner;
+	private boolean isAccessible;
 
-	public BoxExternalFolder(String ref, String name, byte[] key) {
+	public BoxExternalFolder(String ref, String name, byte[] key, boolean isAccessible) {
 		super(ref, name, key);
 	}
+
 
 	@Override
 	public QblECPublicKey getOwner() {
@@ -18,6 +20,11 @@ public class BoxExternalFolder extends BoxFolder implements BoxExternal {
 	@Override
 	public void setOwner(QblECPublicKey owner) {
 		this.owner = owner;
+	}
+
+	@Override
+	public boolean isAccessible() {
+		return isAccessible;
 	}
 
 	@Override

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxExternalFolder.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxExternalFolder.java
@@ -2,32 +2,12 @@ package de.qabel.qabelbox.storage;
 
 import de.qabel.core.crypto.QblECPublicKey;
 
-public class BoxExternalFile extends BoxFile implements BoxExternal {
+public class BoxExternalFolder extends BoxFolder implements BoxExternal {
 
 	public QblECPublicKey owner;
 
-	public BoxExternalFile(QblECPublicKey owner, String block, String name, Long size, Long mtime, byte[] key) {
-		super(block, name, size, mtime, key);
-		this.owner = owner;
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
-		if (!super.equals(o)) return false;
-
-		BoxExternalFile that = (BoxExternalFile) o;
-
-		return !(owner != null ? !owner.equals(that.owner) : that.owner != null);
-
-	}
-
-	@Override
-	public int hashCode() {
-		int result = super.hashCode();
-		result = 31 * result + (owner != null ? owner.hashCode() : 0);
-		return result;
+	public BoxExternalFolder(String ref, String name, byte[] key) {
+		super(ref, name, key);
 	}
 
 	@Override
@@ -38,5 +18,24 @@ public class BoxExternalFile extends BoxFile implements BoxExternal {
 	@Override
 	public void setOwner(QblECPublicKey owner) {
 		this.owner = owner;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		if (!super.equals(o)) return false;
+
+		BoxExternalFolder that = (BoxExternalFolder) o;
+
+		return !(owner != null ? !owner.equals(that.owner) : that.owner != null);
+
+	}
+
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (owner != null ? owner.hashCode() : 0);
+		return result;
 	}
 }

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxExternalReference.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxExternalReference.java
@@ -1,0 +1,49 @@
+package de.qabel.qabelbox.storage;
+
+import de.qabel.core.crypto.QblECPublicKey;
+
+import java.util.Arrays;
+
+public class BoxExternalReference {
+	public boolean isFolder;
+	public String name;
+	public String url;
+	public QblECPublicKey owner;
+	public byte[] key;
+
+	public BoxExternalReference(boolean isFolder, String url, String name, QblECPublicKey owner, byte[] key) {
+		this.isFolder = isFolder;
+		this.name = name;
+		this.url = url;
+		this.owner = owner;
+		this.key = key;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		BoxExternalReference that = (BoxExternalReference) o;
+
+		if (isFolder != that.isFolder) return false;
+		if (url != null ? !url.equals(that.url) : that.url != null) return false;
+		if (owner != null ? !owner.equals(that.owner) : that.owner != null) return false;
+		return Arrays.equals(key, that.key);
+
+	}
+
+	@Override
+	public int hashCode() {
+		int result = (isFolder ? 1 : 0);
+		result = 31 * result + (url != null ? url.hashCode() : 0);
+		result = 31 * result + (owner != null ? owner.hashCode() : 0);
+		result = 31 * result + (key != null ? Arrays.hashCode(key) : 0);
+		return result;
+	}
+
+	@Override
+	protected BoxExternalReference clone() throws CloneNotSupportedException {
+		return new BoxExternalReference(isFolder, url,name,owner,key);
+	}
+}

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxNavigation.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxNavigation.java
@@ -2,8 +2,8 @@ package de.qabel.qabelbox.storage;
 
 import android.support.annotation.Nullable;
 
+import de.qabel.core.crypto.QblECPublicKey;
 import de.qabel.qabelbox.exceptions.QblStorageException;
-import de.qabel.qabelbox.exceptions.QblStorageNotFound;
 
 import java.io.InputStream;
 import java.util.List;
@@ -22,32 +22,32 @@ public interface BoxNavigation {
 	boolean hasParent();
 	void navigateToParent() throws QblStorageException;
 	void navigate(BoxFolder target) throws QblStorageException;
-	BoxNavigation navigate(BoxExternal target);
+	BoxNavigation navigate(BoxExternalReference target);
 
 	List<BoxFile> listFiles() throws QblStorageException;
 	List<BoxFolder> listFolders() throws QblStorageException;
-	List<BoxExternal> listExternals() throws QblStorageException;
-	List<BoxExternalFile> listExternalFiles() throws QblStorageException;
+	List<BoxObject> listExternals() throws QblStorageException;
 
 	BoxFile upload(String name, InputStream content, @Nullable TransferManager.BoxTransferListener boxTransferListener) throws QblStorageException;
 	InputStream download(BoxFile file, @Nullable TransferManager.BoxTransferListener boxTransferListener) throws QblStorageException;
 
-	boolean createFileMetadata(String owner, BoxFile boxFile);
+	boolean createFileMetadata(QblECPublicKey owner, BoxFile boxFile);
+	boolean updateFileMetadata(BoxFile boxFile);
 	boolean removeFileMetadata(BoxFile boxFile);
 
-	void attachExternalFile(String owner, String metaURL, byte[] metaKey) throws QblStorageException;
-	void detachExternalFile(BoxExternalFile boxExternalFile) throws QblStorageException;
+	void attachExternal(boolean isFolder, String name, QblECPublicKey owner, String metaURL, byte[] metaKey) throws QblStorageException;
+	void detachExternal(String name) throws QblStorageException;
 
 	void delete(BoxObject boxObject) throws QblStorageException;
 	void delete(BoxFile boxFile) throws QblStorageException;
 	void delete(BoxFolder boxFolder) throws QblStorageException;
-	void delete(BoxExternal boxExternal) throws QblStorageException;
+	void delete(BoxExternalReference boxExternal) throws QblStorageException;
 
 	BoxFolder createFolder(String name) throws QblStorageException;
 
 	BoxFile rename(BoxFile file, String name) throws QblStorageException;
 	BoxFolder rename(BoxFolder folder, String name) throws QblStorageException;
-	BoxExternal rename(BoxExternal external, String name) throws QblStorageException;
+	BoxExternalReference rename(BoxExternalReference external, String name) throws QblStorageException;
 
 	void reload() throws QblStorageException;
 

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxObject.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxObject.java
@@ -1,27 +1,14 @@
 package de.qabel.qabelbox.storage;
 
+import android.support.annotation.NonNull;
+
 public class BoxObject implements Comparable<BoxObject>  {
 	public String name;
 
 	public BoxObject(String name) {this.name = name;}
 
 	@Override
-	public int compareTo(BoxObject another) {
-		if (this instanceof BoxFile && (another instanceof BoxFile || another instanceof BoxUploadingFile)) {
-			return this.name.compareTo(another.name);
-		}
-		if (this instanceof BoxUploadingFile && (another instanceof BoxFile || another instanceof BoxUploadingFile)) {
-			return this.name.compareTo(another.name);
-		}
-		if (this instanceof BoxFolder && (another instanceof BoxFolder || another instanceof BoxExternal)) {
-			return this.name.compareTo(another.name);
-		}
-		if (this instanceof BoxExternal && (another instanceof BoxFolder || another instanceof BoxExternal)) {
-			return this.name.compareTo(another.name);
-		}
-		if (this instanceof BoxFolder || this instanceof BoxExternal) {
-			return -1;
-		}
-		return 1;
+	public int compareTo(@NonNull BoxObject another) {
+		return this.name.compareTo(another.name);
 	}
 }

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/StorageSearch.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/StorageSearch.java
@@ -349,9 +349,11 @@ public class StorageSearch {
             if (item instanceof BoxFile) {
                 clone.add(((BoxFile) item).clone());
             }
-            if (item instanceof BoxExternal) {
-                clone.add(((BoxExternal) item).clone());
-            } else if (item instanceof BoxFolder) {
+            if (item instanceof BoxExternalFile) {
+                clone.add(((BoxExternalFile) item).clone());
+            } else if (item instanceof BoxExternalFolder){
+				clone.add(((BoxExternalFolder) item).clone());
+			} else if (item instanceof BoxFolder) {
                 clone.add(((BoxFolder) item).clone());
             }
         }


### PR DESCRIPTION
* DirectoryMetadata structure has been changed to treat single file and folder shared in the same way.
* Uploading a new file version updates the related FileMetadata.

TODO:
* [X] Lazy unshare test
* [x] Define how to handle inaccessible BoxExternalReferences. ~~(Currently they are just skipped with a log entry)~~ Solution: isAccessible boolean added to BoxExternal

Changes documented in: https://github.com/Qabel/qabel.github.io/pull/146