### PR TITLE
Fix upload via file uri

### DIFF
--- a/qabelbox/src/main/java/de/qabel/qabelbox/communication/VolumeFileTransferHelper.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/communication/VolumeFileTransferHelper.java
@@ -10,6 +10,7 @@ import android.util.Log;
 
 import org.apache.commons.io.IOUtils;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -27,6 +28,7 @@ import de.qabel.qabelbox.storage.BoxVolume;
 public class VolumeFileTransferHelper {
 
     private static final String TAG = "DownloadUploadHelper";
+	private static final String URI_PREFIX_FILE = "file://";
     public static final String HARDCODED_ROOT = BoxProvider.DOCID_SEPARATOR
             + BoxProvider.BUCKET + BoxProvider.DOCID_SEPARATOR
             + BoxProvider.PREFIX + BoxProvider.DOCID_SEPARATOR + BoxProvider.PATH_SEP;
@@ -35,12 +37,21 @@ public class VolumeFileTransferHelper {
             @Override
             protected Void doInBackground(Void... params) {
 
+				String name;
                 Cursor returnCursor =
                         self.getContentResolver().query(uri, null, null, null, null);
-                int nameIndex = returnCursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
-                returnCursor.moveToFirst();
-                String name = returnCursor.getString(nameIndex);
-                returnCursor.close();
+				if (returnCursor != null) {
+					int nameIndex = returnCursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
+					returnCursor.moveToFirst();
+					name = returnCursor.getString(nameIndex);
+					returnCursor.close();
+				} else if (uri.toString().startsWith(URI_PREFIX_FILE)) {
+					File file = new File(uri.toString());
+					name = file.getName();
+				} else {
+					Log.e(TAG, "Cannot handle URI for upload: " + uri.toString());
+					return null;
+				}
 
                 try {
                     Uri uploadUri = makeUri(name, boxNavigation, boxVolume);

--- a/qabelbox/src/main/java/de/qabel/qabelbox/communication/VolumeFileTransferHelper.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/communication/VolumeFileTransferHelper.java
@@ -53,17 +53,13 @@ public class VolumeFileTransferHelper {
 					return null;
 				}
 
-                try {
-                    Uri uploadUri = makeUri(name, boxNavigation, boxVolume);
-
-                    InputStream content = self.getContentResolver().openInputStream(uri);
-                    OutputStream upload = self.getContentResolver().openOutputStream(uploadUri, "w");
+				Uri uploadUri = makeUri(name, boxNavigation, boxVolume);
+				try (InputStream content = self.getContentResolver().openInputStream(uri);
+					 OutputStream upload = self.getContentResolver().openOutputStream(uploadUri, "w") ){
                     if (upload == null || content == null) {
                         return null;
                     }
                     IOUtils.copy(content, upload);
-                    content.close();
-                    upload.close();
                 } catch (IOException e) {
                     Log.e(TAG, "Upload failed", e);
                 }
@@ -95,18 +91,13 @@ public class VolumeFileTransferHelper {
                 .getReadableKeyIdentifier();
         Uri uploadUri = DocumentsContract.buildDocumentUri(
                 BoxProvider.AUTHORITY, keyIdentifier + HARDCODED_ROOT + targetFolder + displayName);
-        try {
-            OutputStream outputStream = context.getContentResolver().openOutputStream(uploadUri, "w");
-            if (outputStream == null) {
-                return false;
-            }
-            InputStream inputStream = context.getContentResolver().openInputStream(uri);
-            if (inputStream == null) {
-                return false;
-            }
-            IOUtils.copy(inputStream, outputStream);
-            outputStream.close();
-            inputStream.close();
+		try (OutputStream outputStream = context.getContentResolver().openOutputStream(uploadUri, "w");
+			 InputStream inputStream = context.getContentResolver().openInputStream(uri)) {
+			if (inputStream == null || outputStream == null) {
+				return false;
+			}
+			IOUtils.copy(inputStream, outputStream);
+			inputStream.close();
         } catch (IOException e) {
             Log.e(TAG, "Error opening output stream for upload", e);
         }


### PR DESCRIPTION
Uploading files that are shared from an other app failed, if the app provided a "file://" URI instead of a "content://" URI. (e.g. the default cyanogenmod file manager).

Alternative handling only happens if the getContentResolver call failed, because I expect this to be the default path.

This PR allows to handle "file://" URIs and also replaces the try with manual close (which by the way would not close if an exception would happen) with try-with-ressources.

Closes #240