### PR TITLE
Fix downloading shared files

### DIFF
--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/helper/BoxObjectComparatorsTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/helper/BoxObjectComparatorsTest.java
@@ -67,6 +67,6 @@ public class BoxObjectComparatorsTest {
 
 	@NonNull
 	private BoxFile getBoxFile(String name) {
-		return new BoxFile("", name, 0L, 0L, new byte[]{0x01, 0x02});
+		return new BoxFile("Prefix", "Block", name, 0L, 0L, new byte[]{0x01, 0x02});
 	}
 }

--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/BoxFileTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/BoxFileTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 
 public class BoxFileTest extends AndroidTestCase {
 
+	private static final String PREFIX = "PREFIX";
 	private static final String NAME = "BoxFile";
 	private static final String BLOCK = "Block";
 	private static final Long SIZE = 1000L;
@@ -16,7 +17,7 @@ public class BoxFileTest extends AndroidTestCase {
 
 	@Test
 	public void testBoxFileParcelable() {
-		BoxFile boxFile = new BoxFile(NAME, BLOCK, SIZE, MTIME, KEY);
+		BoxFile boxFile = new BoxFile(PREFIX, NAME, BLOCK, SIZE, MTIME, KEY);
 		Bundle bundle = new Bundle();
 		bundle.putParcelable("FILE", boxFile);
 

--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/DirectoryMetadataTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/DirectoryMetadataTest.java
@@ -64,7 +64,7 @@ public class DirectoryMetadataTest extends TestCase{
 
 	@Test
 	public void testExternalOperations() throws QblStorageException {
-		BoxExternalReference external = new BoxExternalReference(false, "prefix", "https://foobar", "name",
+		BoxExternalReference external = new BoxExternalReference(false, "https://foobar", "name",
 				new QblECKeyPair().getPub(), new byte[] {1,2,});
 		dm.insertExternalReference(external);
 		assertThat(dm.listExternalReferences().size(), is(1));

--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/DirectoryMetadataTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/DirectoryMetadataTest.java
@@ -43,7 +43,7 @@ public class DirectoryMetadataTest extends TestCase{
 
 	@Test
 	public void testFileOperations() throws QblStorageException {
-		BoxFile file = new BoxFile("block", "name", 0L, 0L, new byte[] {1,2,}, "metablock", new byte[]{0x03, 0x04});
+		BoxFile file = new BoxFile("prefix", "block", "name", 0L, 0L, new byte[] {1,2,}, "metablock", new byte[]{0x03, 0x04});
 		dm.insertFile(file);
 		assertThat(dm.listFiles().size(), is(1));
 		assertThat(file, equalTo(dm.listFiles().get(0)));
@@ -64,7 +64,7 @@ public class DirectoryMetadataTest extends TestCase{
 
 	@Test
 	public void testExternalOperations() throws QblStorageException {
-		BoxExternalReference external = new BoxExternalReference(false, "https://foobar", "name",
+		BoxExternalReference external = new BoxExternalReference(false, "prefix", "https://foobar", "name",
 				new QblECKeyPair().getPub(), new byte[] {1,2,});
 		dm.insertExternalReference(external);
 		assertThat(dm.listExternalReferences().size(), is(1));

--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/FileCacheTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/FileCacheTest.java
@@ -45,7 +45,7 @@ public class FileCacheTest {
 	@NonNull
 	private BoxFile getBoxFile() {
 		Long now = System.currentTimeMillis()/ 1000;
-		return new BoxFile("ref", "name", 20L, now, null);
+		return new BoxFile("prefix", "block", "name", 20L, now, null);
 	}
 
 	@Test

--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/FileMetadataTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/FileMetadataTest.java
@@ -23,7 +23,7 @@ public class FileMetadataTest {
 
 	@Before
 	public void setUp() throws Exception {
-		boxFile = new BoxFile("Block", "Name", 1000L, 1000L, new byte[]{0x00, 0x01, 0x02});
+		boxFile = new BoxFile("Prefix", "Block", "Name", 1000L, 1000L, new byte[]{0x00, 0x01, 0x02});
 		fileMetadata = new FileMetadata(OWNER, boxFile, new File(System.getProperty("java.io.tmpdir")));
 	}
 

--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/SearchTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/SearchTest.java
@@ -412,7 +412,7 @@ public class SearchTest extends AndroidTestCase {
 		if (o instanceof BoxFile) {
 			BoxFile tmp = (BoxFile) o;
 
-			return new BoxFile(tmp.block, tmp.name, tmp.size, tmp.mtime, tmp.key);
+			return new BoxFile(tmp.prefix, tmp.block, tmp.name, tmp.size, tmp.mtime, tmp.key);
 		} else {
 			BoxFolder tmp = (BoxFolder) o;
 

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/AbstractNavigation.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/AbstractNavigation.java
@@ -273,13 +273,12 @@ public abstract class AbstractNavigation implements BoxNavigation {
 	public List<BoxObject> listExternals() throws QblStorageException {
 		List<BoxObject> boxExternals = new ArrayList<>();
 		for (BoxExternalReference boxExternalRefs : dm.listExternalReferences()) {
-			String[] splitURL = boxExternalRefs.url.split("/");
 			try {
-				File out = getMetadataFile(boxExternalRefs.url, boxExternalRefs.key);
+				File out = getMetadataFile(boxExternalRefs.prefix, boxExternalRefs.block, boxExternalRefs.key);
 				if (boxExternalRefs.isFolder) {
 					//TODO: Check DirectoryMetadata handling
 					DirectoryMetadata directoryMetadata =
-							DirectoryMetadata.openDatabase(out, dm.deviceId, splitURL[1], dm.getTempDir());
+							DirectoryMetadata.openDatabase(out, dm.deviceId, boxExternalRefs.block, dm.getTempDir());
 					boxExternals.addAll(directoryMetadata.listFiles());
 					boxExternals.addAll(directoryMetadata.listFolders());
 				} else {
@@ -288,12 +287,12 @@ public abstract class AbstractNavigation implements BoxNavigation {
 				}
 			}
 			catch (QblStorageException e) {
-				Log.e(TAG, "Cannot load metadata file: " + boxExternalRefs.url);
+				Log.e(TAG, "Cannot load metadata file: " + boxExternalRefs.prefix + '/' + boxExternalRefs.block);
 				if (boxExternalRefs.isFolder) {
-					boxExternals.add(new BoxExternalFolder(boxExternalRefs.url, boxExternalRefs.name,
+					boxExternals.add(new BoxExternalFolder(boxExternalRefs.getRef(), boxExternalRefs.name,
 							boxExternalRefs.key, false));
 				} else {
-					boxExternals.add(new BoxExternalFile(boxExternalRefs.owner, boxExternalRefs.url,
+					boxExternals.add(new BoxExternalFile(boxExternalRefs.owner, boxExternalRefs.prefix, boxExternalRefs.block,
 							boxExternalRefs.name, boxExternalRefs.key, false));
 				}
 			}
@@ -302,9 +301,8 @@ public abstract class AbstractNavigation implements BoxNavigation {
 	}
 
 	@NonNull
-	private File getMetadataFile(String url, byte[] key) throws QblStorageException {
-		String[] splitURL = url.split("/");
-		File encryptedMetadata = blockingDownload(splitURL[0], splitURL[1], null);
+	private File getMetadataFile(String prefix, String block, byte[] key) throws QblStorageException {
+		File encryptedMetadata = blockingDownload(prefix, block, null);
 
 		File out = new File(context.getExternalCacheDir(), UUID.randomUUID().toString());
 
@@ -322,7 +320,7 @@ public abstract class AbstractNavigation implements BoxNavigation {
 						  @Nullable TransferManager.BoxTransferListener boxTransferListener) throws QblStorageException {
 		KeyParameter key = cryptoUtils.generateSymmetricKey();
 		String block = UUID.randomUUID().toString();
-		BoxFile boxFile = new BoxFile(block, name, null, 0L, key.getKey());
+		BoxFile boxFile = new BoxFile(prefix, block, name, null, 0L, key.getKey());
 		SimpleEntry<Long, Long> mtimeAndSize = uploadEncrypted(content, key, prefix, BLOCKS_PREFIX + block, boxTransferListener);
 		boxFile.mtime = mtimeAndSize.getKey();
 		boxFile.size = mtimeAndSize.getValue();
@@ -360,8 +358,7 @@ public abstract class AbstractNavigation implements BoxNavigation {
 	}
 
 	@Override
-	public InputStream download(BoxFile boxFile,
-								@Nullable TransferManager.BoxTransferListener boxTransferListener) throws QblStorageException {
+	public InputStream download(BoxFile boxFile, @Nullable TransferManager.BoxTransferListener boxTransferListener) throws QblStorageException {
 		File download = cache.get(boxFile);
 		cache.close();
 		if (download == null) {
@@ -386,17 +383,17 @@ public abstract class AbstractNavigation implements BoxNavigation {
 	@Override
 	public BoxExternalReference createFileMetadata(QblECPublicKey owner, BoxFile boxFile) throws QblStorageException {
 		if (boxFile.meta != null || boxFile.metakey != null) {
-			return new BoxExternalReference(false, boxFile.meta, boxFile.name, owner, boxFile.metakey);
+			return new BoxExternalReference(false, boxFile.prefix, boxFile.meta, boxFile.name, owner, boxFile.metakey);
 		}
-		String block = UUID.randomUUID().toString();
-		boxFile.meta = prefix + '/' + block;
+		String metaBlock = UUID.randomUUID().toString();
 		KeyParameter key = cryptoUtils.generateSymmetricKey();
+		boxFile.meta = metaBlock;
 		boxFile.metakey = key.getKey();
 
 		try {
 			FileMetadata fileMetadata = new FileMetadata(owner, boxFile, dm.getTempDir());
 			FileInputStream fileInputStream = new FileInputStream(fileMetadata.getPath());
-			uploadEncrypted(fileInputStream, key, prefix, block, null);
+			uploadEncrypted(fileInputStream, key, prefix, metaBlock, null);
 
 			// Overwrite = delete old file, upload new file
 			BoxFile oldFile = dm.getFile(boxFile.name);
@@ -407,7 +404,7 @@ public abstract class AbstractNavigation implements BoxNavigation {
 		} catch (QblStorageException | FileNotFoundException e) {
 			throw new QblStorageException("Could not create or upload FileMetadata", e);
 		}
-		return new BoxExternalReference(false, boxFile.meta, boxFile.name, owner, boxFile.metakey);
+		return new BoxExternalReference(false, boxFile.prefix, metaBlock, boxFile.name, owner, boxFile.metakey);
 	}
 
 	/**
@@ -421,12 +418,11 @@ public abstract class AbstractNavigation implements BoxNavigation {
 			return false;
 		}
 		try {
-			File out = getMetadataFile(boxFile.meta, boxFile.metakey);
+			File out = getMetadataFile(boxFile.prefix, boxFile.meta, boxFile.metakey);
 			FileMetadata fileMetadataOld = new FileMetadata(out);
 			FileMetadata fileMetadataNew = new FileMetadata(fileMetadataOld.getFile().owner, boxFile, dm.getTempDir());
 			FileInputStream fileInputStream = new FileInputStream(fileMetadataNew.getPath());
-			String[] splitURL = boxFile.meta.split("/");
-			uploadEncrypted(fileInputStream, new KeyParameter(boxFile.metakey), splitURL[0], splitURL[1], null);
+			uploadEncrypted(fileInputStream, new KeyParameter(boxFile.metakey), boxFile.prefix, boxFile.meta, null);
 		} catch (QblStorageException | FileNotFoundException e) {
 			Log.e(TAG, "Could not create or upload FileMetadata", e);
 			return false;
@@ -445,9 +441,8 @@ public abstract class AbstractNavigation implements BoxNavigation {
 		if (boxFile.meta == null || boxFile.metakey == null) {
 			return false;
 		}
-		String[] splitURL = boxFile.meta.split("/");
 
-		blockingDelete(splitURL[0], splitURL[1]);
+		blockingDelete(boxFile.prefix, boxFile.meta);
 		boxFile.meta = null;
 		boxFile.metakey = null;
 
@@ -476,7 +471,7 @@ public abstract class AbstractNavigation implements BoxNavigation {
 
 	private File refreshCache(BoxFile boxFile, @Nullable TransferManager.BoxTransferListener boxTransferListener) throws QblStorageNotFound {
 		logger.info("Refreshing cache: "+ boxFile.block);
-		File download = blockingDownload(prefix, BLOCKS_PREFIX + boxFile.block, boxTransferListener);
+		File download = blockingDownload(boxFile.prefix, BLOCKS_PREFIX + boxFile.block, boxTransferListener);
 		cache.put(boxFile, download);
 		cache.close();
 		return download;

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/AbstractNavigation.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/AbstractNavigation.java
@@ -274,11 +274,11 @@ public abstract class AbstractNavigation implements BoxNavigation {
 		List<BoxObject> boxExternals = new ArrayList<>();
 		for (BoxExternalReference boxExternalRefs : dm.listExternalReferences()) {
 			try {
-				File out = getMetadataFile(boxExternalRefs.prefix, boxExternalRefs.block, boxExternalRefs.key);
+				File out = getMetadataFile(boxExternalRefs.getPrefix(), boxExternalRefs.getBlock(), boxExternalRefs.key);
 				if (boxExternalRefs.isFolder) {
 					//TODO: Check DirectoryMetadata handling
 					DirectoryMetadata directoryMetadata =
-							DirectoryMetadata.openDatabase(out, dm.deviceId, boxExternalRefs.block, dm.getTempDir());
+							DirectoryMetadata.openDatabase(out, dm.deviceId, boxExternalRefs.getBlock(), dm.getTempDir());
 					boxExternals.addAll(directoryMetadata.listFiles());
 					boxExternals.addAll(directoryMetadata.listFolders());
 				} else {
@@ -287,12 +287,12 @@ public abstract class AbstractNavigation implements BoxNavigation {
 				}
 			}
 			catch (QblStorageException e) {
-				Log.e(TAG, "Cannot load metadata file: " + boxExternalRefs.prefix + '/' + boxExternalRefs.block);
+				Log.e(TAG, "Cannot load metadata file: " + boxExternalRefs.getPrefix() + '/' + boxExternalRefs.getBlock());
 				if (boxExternalRefs.isFolder) {
-					boxExternals.add(new BoxExternalFolder(boxExternalRefs.getRef(), boxExternalRefs.name,
+					boxExternals.add(new BoxExternalFolder(boxExternalRefs.url, boxExternalRefs.name,
 							boxExternalRefs.key, false));
 				} else {
-					boxExternals.add(new BoxExternalFile(boxExternalRefs.owner, boxExternalRefs.prefix, boxExternalRefs.block,
+					boxExternals.add(new BoxExternalFile(boxExternalRefs.owner, boxExternalRefs.getPrefix(), boxExternalRefs.getBlock(),
 							boxExternalRefs.name, boxExternalRefs.key, false));
 				}
 			}
@@ -383,7 +383,7 @@ public abstract class AbstractNavigation implements BoxNavigation {
 	@Override
 	public BoxExternalReference createFileMetadata(QblECPublicKey owner, BoxFile boxFile) throws QblStorageException {
 		if (boxFile.meta != null || boxFile.metakey != null) {
-			return new BoxExternalReference(false, boxFile.prefix, boxFile.meta, boxFile.name, owner, boxFile.metakey);
+			return new BoxExternalReference(false, boxFile.prefix + '/' + boxFile.meta, boxFile.name, owner, boxFile.metakey);
 		}
 		String metaBlock = UUID.randomUUID().toString();
 		KeyParameter key = cryptoUtils.generateSymmetricKey();
@@ -404,7 +404,7 @@ public abstract class AbstractNavigation implements BoxNavigation {
 		} catch (QblStorageException | FileNotFoundException e) {
 			throw new QblStorageException("Could not create or upload FileMetadata", e);
 		}
-		return new BoxExternalReference(false, boxFile.prefix, metaBlock, boxFile.name, owner, boxFile.metakey);
+		return new BoxExternalReference(false, boxFile.prefix + '/' + metaBlock, boxFile.name, owner, boxFile.metakey);
 	}
 
 	/**

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxExternalFile.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxExternalFile.java
@@ -7,14 +7,14 @@ public class BoxExternalFile extends BoxFile implements BoxExternal {
 	public QblECPublicKey owner;
 	private boolean isAccessible;
 
-	public BoxExternalFile(QblECPublicKey owner, String block, String name, Long size, Long mtime, byte[] key) {
-		super(block, name, size, mtime, key);
+	public BoxExternalFile(QblECPublicKey owner, String prefix, String block, String name, Long size, Long mtime, byte[] key) {
+		super(prefix, block, name, size, mtime, key);
 		this.owner = owner;
 		this.isAccessible = true;
 	}
 
-	public BoxExternalFile(QblECPublicKey owner, String block, String name, byte[] key, boolean isAccessible) {
-		super(block, name, 0L, 0L, key);
+	public BoxExternalFile(QblECPublicKey owner, String prefix, String block, String name, byte[] key, boolean isAccessible) {
+		super(prefix, block, name, 0L, 0L, key);
 		this.owner = owner;
 		this.isAccessible = isAccessible;
 	}

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxExternalReference.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxExternalReference.java
@@ -7,16 +7,22 @@ import java.util.Arrays;
 public class BoxExternalReference {
 	public boolean isFolder;
 	public String name;
-	public String url;
+	public String prefix;
+	public String block;
 	public QblECPublicKey owner;
 	public byte[] key;
 
-	public BoxExternalReference(boolean isFolder, String url, String name, QblECPublicKey owner, byte[] key) {
+	public BoxExternalReference(boolean isFolder, String prefix, String block, String name, QblECPublicKey owner, byte[] key) {
 		this.isFolder = isFolder;
 		this.name = name;
-		this.url = url;
+		this.prefix = prefix;
+		this.block = block;
 		this.owner = owner;
 		this.key = key;
+	}
+
+	public String getRef() {
+		return prefix + '/' + block;
 	}
 
 	@Override
@@ -27,7 +33,9 @@ public class BoxExternalReference {
 		BoxExternalReference that = (BoxExternalReference) o;
 
 		if (isFolder != that.isFolder) return false;
-		if (url != null ? !url.equals(that.url) : that.url != null) return false;
+		if (name != null ? !name.equals(that.name) : that.name != null) return false;
+		if (prefix != null ? !prefix.equals(that.prefix) : that.prefix != null) return false;
+		if (block != null ? !block.equals(that.block) : that.block != null) return false;
 		if (owner != null ? !owner.equals(that.owner) : that.owner != null) return false;
 		return Arrays.equals(key, that.key);
 
@@ -36,7 +44,9 @@ public class BoxExternalReference {
 	@Override
 	public int hashCode() {
 		int result = (isFolder ? 1 : 0);
-		result = 31 * result + (url != null ? url.hashCode() : 0);
+		result = 31 * result + (name != null ? name.hashCode() : 0);
+		result = 31 * result + (prefix != null ? prefix.hashCode() : 0);
+		result = 31 * result + (block != null ? block.hashCode() : 0);
 		result = 31 * result + (owner != null ? owner.hashCode() : 0);
 		result = 31 * result + (key != null ? Arrays.hashCode(key) : 0);
 		return result;
@@ -44,6 +54,6 @@ public class BoxExternalReference {
 
 	@Override
 	protected BoxExternalReference clone() throws CloneNotSupportedException {
-		return new BoxExternalReference(isFolder, url,name,owner,key);
+		return new BoxExternalReference(isFolder, prefix, block, name, owner, key);
 	}
 }

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxExternalReference.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxExternalReference.java
@@ -7,22 +7,24 @@ import java.util.Arrays;
 public class BoxExternalReference {
 	public boolean isFolder;
 	public String name;
-	public String prefix;
-	public String block;
+	public String url;
 	public QblECPublicKey owner;
 	public byte[] key;
 
-	public BoxExternalReference(boolean isFolder, String prefix, String block, String name, QblECPublicKey owner, byte[] key) {
+	public BoxExternalReference(boolean isFolder, String url, String name, QblECPublicKey owner, byte[] key) {
 		this.isFolder = isFolder;
 		this.name = name;
-		this.prefix = prefix;
-		this.block = block;
+		this.url = url;
 		this.owner = owner;
 		this.key = key;
 	}
 
-	public String getRef() {
-		return prefix + '/' + block;
+	public String getPrefix() {
+		return url.split("/")[0];
+	}
+
+	public String getBlock() {
+		return url.split("/")[1];
 	}
 
 	@Override
@@ -33,9 +35,7 @@ public class BoxExternalReference {
 		BoxExternalReference that = (BoxExternalReference) o;
 
 		if (isFolder != that.isFolder) return false;
-		if (name != null ? !name.equals(that.name) : that.name != null) return false;
-		if (prefix != null ? !prefix.equals(that.prefix) : that.prefix != null) return false;
-		if (block != null ? !block.equals(that.block) : that.block != null) return false;
+		if (url != null ? !url.equals(that.url) : that.url != null) return false;
 		if (owner != null ? !owner.equals(that.owner) : that.owner != null) return false;
 		return Arrays.equals(key, that.key);
 
@@ -44,9 +44,7 @@ public class BoxExternalReference {
 	@Override
 	public int hashCode() {
 		int result = (isFolder ? 1 : 0);
-		result = 31 * result + (name != null ? name.hashCode() : 0);
-		result = 31 * result + (prefix != null ? prefix.hashCode() : 0);
-		result = 31 * result + (block != null ? block.hashCode() : 0);
+		result = 31 * result + (url != null ? url.hashCode() : 0);
 		result = 31 * result + (owner != null ? owner.hashCode() : 0);
 		result = 31 * result + (key != null ? Arrays.hashCode(key) : 0);
 		return result;
@@ -54,6 +52,6 @@ public class BoxExternalReference {
 
 	@Override
 	protected BoxExternalReference clone() throws CloneNotSupportedException {
-		return new BoxExternalReference(isFolder, prefix, block, name, owner, key);
+		return new BoxExternalReference(isFolder, url,name,owner,key);
 	}
 }

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxFile.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxFile.java
@@ -6,6 +6,7 @@ import android.os.Parcelable;
 import java.util.Arrays;
 
 public class BoxFile extends BoxObject implements Parcelable {
+	public String prefix;
 	public String block;
 	public Long size;
 	public Long mtime;
@@ -20,19 +21,20 @@ public class BoxFile extends BoxObject implements Parcelable {
 
 		BoxFile boxFile = (BoxFile) o;
 
+		if (prefix != null ? !prefix.equals(boxFile.prefix) : boxFile.prefix != null) return false;
 		if (block != null ? !block.equals(boxFile.block) : boxFile.block != null) return false;
-		if (name != null ? !name.equals(boxFile.name) : boxFile.name != null) return false;
 		if (size != null ? !size.equals(boxFile.size) : boxFile.size != null) return false;
 		if (mtime != null ? !mtime.equals(boxFile.mtime) : boxFile.mtime != null) return false;
 		if (!Arrays.equals(key, boxFile.key)) return false;
 		if (meta != null ? !meta.equals(boxFile.meta) : boxFile.meta != null) return false;
 		return Arrays.equals(metakey, boxFile.metakey);
+
 	}
 
 	@Override
 	public int hashCode() {
-		int result = block != null ? block.hashCode() : 0;
-		result = 31 * result + (name != null ? name.hashCode() : 0);
+		int result = prefix != null ? prefix.hashCode() : 0;
+		result = 31 * result + (block != null ? block.hashCode() : 0);
 		result = 31 * result + (size != null ? size.hashCode() : 0);
 		result = 31 * result + (mtime != null ? mtime.hashCode() : 0);
 		result = 31 * result + (key != null ? Arrays.hashCode(key) : 0);
@@ -41,16 +43,18 @@ public class BoxFile extends BoxObject implements Parcelable {
 		return result;
 	}
 
-	public BoxFile(String block, String name, Long size, Long mtime, byte[] key) {
+	public BoxFile(String prefix, String block, String name, Long size, Long mtime, byte[] key) {
 		super(name);
+		this.prefix = prefix;
 		this.block = block;
 		this.size = size;
 		this.mtime = mtime;
 		this.key = key;
 	}
 
-	public BoxFile(String block, String name, Long size, Long mtime, byte[] key, String meta, byte[] metaKey) {
+	public BoxFile(String prefix, String block, String name, Long size, Long mtime, byte[] key, String meta, byte[] metaKey) {
 		super(name);
+		this.prefix = prefix;
 		this.block = block;
 		this.size = size;
 		this.mtime = mtime;
@@ -61,7 +65,7 @@ public class BoxFile extends BoxObject implements Parcelable {
 
 	@Override
 	protected BoxFile clone() throws CloneNotSupportedException {
-		return new BoxFile(block,name,size,mtime, key, meta,metakey);
+		return new BoxFile(prefix, block, name, size, mtime, key, meta, metakey);
 	}
 
 	/**
@@ -78,6 +82,7 @@ public class BoxFile extends BoxObject implements Parcelable {
 
 	protected BoxFile(Parcel in) {
 		super(in.readString());
+		prefix = in.readString();
 		block = in.readString();
 		key = new byte[in.readInt()];
 		in.readByteArray(key);
@@ -93,6 +98,7 @@ public class BoxFile extends BoxObject implements Parcelable {
 	@Override
 	public void writeToParcel(Parcel dest, int flags) {
 		dest.writeString(name);
+		dest.writeString(prefix);
 		dest.writeString(block);
 		dest.writeByteArray(key);
 		if (size == null) {

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/DirectoryMetadata.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/DirectoryMetadata.java
@@ -66,8 +66,7 @@ class DirectoryMetadata {
 					" owner BLOB NOT NULL," +
 					" name VARCHAR(255)NOT NULL PRIMARY KEY," +
 					" key BLOB NOT NULL," +
-					" prefix VARCHAR(255) NOT NULL, " +
-					" block VARCHAR(255) NOT NULL )",
+					" url TEXT NOT NULL )",
 			"INSERT INTO spec_version (version) VALUES(0)"
 	};
 	private final File tempDir;
@@ -417,12 +416,12 @@ class DirectoryMetadata {
 	List<BoxExternalReference> listExternalReferences() throws QblStorageException {
 		try (Statement statement = connection.createStatement()){
 			ResultSet rs = statement.executeQuery(
-					"SELECT is_folder, prefix, block, name, owner, key FROM externals");
+					"SELECT is_folder, url, name, owner, key FROM externals");
 			List<BoxExternalReference> files = new ArrayList<>();
 			while (rs.next()) {
 				files.add(
-						new BoxExternalReference(rs.getBoolean(1), rs.getString(2), rs.getString(3), rs.getString(4),
-								new QblECPublicKey(rs.getBytes(5)), rs.getBytes(6)));
+						new BoxExternalReference(rs.getBoolean(1), rs.getString(2), rs.getString(3),
+								new QblECPublicKey(rs.getBytes(4)), rs.getBytes(5)));
 			}
 			return files;
 		} catch (SQLException e) {
@@ -436,13 +435,12 @@ class DirectoryMetadata {
 			throw new QblStorageNameConflict(file.name);
 		}
 		try (PreparedStatement st = connection.prepareStatement(
-			 "INSERT INTO externals (is_folder, prefix, block, name, owner, key) VALUES(?, ?, ?, ?, ?, ?)")){
+			 "INSERT INTO externals (is_folder, url, name, owner, key) VALUES(?, ?, ?, ?, ?)")){
 			st.setBoolean(1, file.isFolder);
-			st.setString(2, file.prefix);
-			st.setString(3, file.block);
-			st.setString(4, file.name);
-			st.setBytes(5, file.owner.getKey());
-			st.setBytes(6, file.key);
+			st.setString(2, file.url);
+			st.setString(3, file.name);
+			st.setBytes(4, file.owner.getKey());
+			st.setBytes(5, file.key);
 			if (st.executeUpdate() != 1) {
 				throw new QblStorageException("Failed to insert file");
 			}

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/DirectoryMetadata.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/DirectoryMetadata.java
@@ -49,6 +49,7 @@ class DirectoryMetadata {
 					" recipient BLOB NOT NULL," +
 					" type INTEGER NOT NULL )",
 			"CREATE TABLE files (" +
+					" prefix VARCHAR(255) NOT NULL," +
 					" block VARCHAR(255) NOT NULL," +
 					" name VARCHAR(255) NULL PRIMARY KEY," +
 					" size LONG NOT NULL," +
@@ -65,7 +66,8 @@ class DirectoryMetadata {
 					" owner BLOB NOT NULL," +
 					" name VARCHAR(255)NOT NULL PRIMARY KEY," +
 					" key BLOB NOT NULL," +
-					" url TEXT NOT NULL )",
+					" prefix VARCHAR(255) NOT NULL, " +
+					" block VARCHAR(255) NOT NULL )",
 			"INSERT INTO spec_version (version) VALUES(0)"
 	};
 	private final File tempDir;
@@ -343,11 +345,11 @@ class DirectoryMetadata {
 		try {
 			statement = connection.createStatement();
 			ResultSet rs = statement.executeQuery(
-					"SELECT block, name, size, mtime, key, meta, metakey FROM files");
+					"SELECT prefix, block, name, size, mtime, key, meta, metakey FROM files");
 			List<BoxFile> files = new ArrayList<>();
 			while (rs.next()) {
-				files.add(new BoxFile(rs.getString(1),
-						rs.getString(2), rs.getLong(3), rs.getLong(4), rs.getBytes(5), rs.getString(6), rs.getBytes(7)));
+				files.add(new BoxFile(rs.getString(1), rs.getString(2),
+						rs.getString(3), rs.getLong(4), rs.getLong(5), rs.getBytes(6), rs.getString(7), rs.getBytes(8)));
 			}
 			return files;
 		} catch (SQLException e) {
@@ -372,14 +374,15 @@ class DirectoryMetadata {
 		PreparedStatement st = null;
 		try {
 			st = connection.prepareStatement(
-					"INSERT INTO files (block, name, size, mtime, key, meta, metakey) VALUES(?, ?, ?, ?, ?, ?, ?)");
-			st.setString(1, file.block);
-			st.setString(2, file.name);
-			st.setLong(3, file.size);
-			st.setLong(4, file.mtime);
-			st.setBytes(5, file.key);
-			st.setString(6, file.meta);
-			st.setBytes(7, file.metakey);
+					"INSERT INTO files (prefix, block, name, size, mtime, key, meta, metakey) VALUES(?, ?, ?, ?, ?, ?, ?, ?)");
+			st.setString(1, file.prefix);
+			st.setString(2, file.block);
+			st.setString(3, file.name);
+			st.setLong(4, file.size);
+			st.setLong(5, file.mtime);
+			st.setBytes(6, file.key);
+			st.setString(7, file.meta);
+			st.setBytes(8, file.metakey);
 			if (st.executeUpdate() != 1) {
 				throw new QblStorageException("Failed to insert file");
 			}
@@ -414,12 +417,12 @@ class DirectoryMetadata {
 	List<BoxExternalReference> listExternalReferences() throws QblStorageException {
 		try (Statement statement = connection.createStatement()){
 			ResultSet rs = statement.executeQuery(
-					"SELECT is_folder, url, name, owner, key FROM externals");
+					"SELECT is_folder, prefix, block, name, owner, key FROM externals");
 			List<BoxExternalReference> files = new ArrayList<>();
 			while (rs.next()) {
 				files.add(
-						new BoxExternalReference(rs.getBoolean(1), rs.getString(2), rs.getString(3),
-								new QblECPublicKey(rs.getBytes(4)), rs.getBytes(5)));
+						new BoxExternalReference(rs.getBoolean(1), rs.getString(2), rs.getString(3), rs.getString(4),
+								new QblECPublicKey(rs.getBytes(5)), rs.getBytes(6)));
 			}
 			return files;
 		} catch (SQLException e) {
@@ -433,12 +436,13 @@ class DirectoryMetadata {
 			throw new QblStorageNameConflict(file.name);
 		}
 		try (PreparedStatement st = connection.prepareStatement(
-			 "INSERT INTO externals (is_folder, url, name, owner, key) VALUES(?, ?, ?, ?, ?)")){
+			 "INSERT INTO externals (is_folder, prefix, block, name, owner, key) VALUES(?, ?, ?, ?, ?, ?)")){
 			st.setBoolean(1, file.isFolder);
-			st.setString(2, file.url);
-			st.setString(3, file.name);
-			st.setBytes(4, file.owner.getKey());
-			st.setBytes(5, file.key);
+			st.setString(2, file.prefix);
+			st.setString(3, file.block);
+			st.setString(4, file.name);
+			st.setBytes(5, file.owner.getKey());
+			st.setBytes(6, file.key);
 			if (st.executeUpdate() != 1) {
 				throw new QblStorageException("Failed to insert file");
 			}
@@ -531,12 +535,12 @@ class DirectoryMetadata {
 		PreparedStatement statement = null;
 		try {
 			statement = connection.prepareStatement(
-					"SELECT block, name, size, mtime, key, meta, metakey FROM files WHERE name=?");
+					"SELECT prefix, block, name, size, mtime, key, meta, metakey FROM files WHERE name=?");
 			statement.setString(1, name);
 			ResultSet rs = statement.executeQuery();
 			if (rs.next()) {
-				return new BoxFile(rs.getString(1),
-						rs.getString(2), rs.getLong(3), rs.getLong(4), rs.getBytes(5), rs.getString(6), rs.getBytes(7));
+				return new BoxFile(rs.getString(1), rs.getString(2),
+						rs.getString(3), rs.getLong(4), rs.getLong(5), rs.getBytes(6), rs.getString(7), rs.getBytes(8));
 			}
 			return null;
 		} catch (SQLException e) {

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/FileMetadata.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/FileMetadata.java
@@ -28,6 +28,7 @@ class FileMetadata {
 					" version INTEGER PRIMARY KEY )",
 			"CREATE TABLE file (" +
 					" owner BLOB NOT NULL," +
+					" prefix VARCHAR(255) NOT NULL," +
 					" block VARCHAR(255) NOT NULL," +
 					" name VARCHAR(255) NULL PRIMARY KEY," +
 					" size LONG NOT NULL," +
@@ -74,13 +75,14 @@ class FileMetadata {
 
 	private void insertFile(QblECPublicKey owner, BoxFile boxFile) throws QblStorageException {
 		try (PreparedStatement statement = connection.prepareStatement(
-					"INSERT INTO file (owner, block, name, size, mtime, key) VALUES(?, ?, ?, ?, ?, ?)")) {
+					"INSERT INTO file (owner, prefix, block, name, size, mtime, key) VALUES(?, ?, ?, ?, ?, ?, ?)")) {
 			statement.setBytes(1, owner.getKey());
-			statement.setString(2, boxFile.block);
-			statement.setString(3, boxFile.name);
-			statement.setLong(4, boxFile.size);
-			statement.setLong(5, boxFile.mtime);
-			statement.setBytes(6, boxFile.key);
+			statement.setString(2, boxFile.prefix);
+			statement.setString(3, boxFile.block);
+			statement.setString(4, boxFile.name);
+			statement.setLong(5, boxFile.size);
+			statement.setLong(6, boxFile.mtime);
+			statement.setBytes(7, boxFile.key);
 			if (statement.executeUpdate() != 1) {
 				throw new QblStorageException("Failed to insert file");
 			}
@@ -119,10 +121,10 @@ class FileMetadata {
 
 	BoxExternalFile getFile() throws QblStorageException {
 		try (Statement statement = connection.createStatement()) {
-			ResultSet rs = statement.executeQuery("SELECT owner, block, name, size, mtime, key FROM file LIMIT 1");
+			ResultSet rs = statement.executeQuery("SELECT owner, prefix, block, name, size, mtime, key FROM file LIMIT 1");
 			if (rs.next()) {
-				return new BoxExternalFile(new QblECPublicKey(rs.getBytes(1)), rs.getString(2),
-						rs.getString(3), rs.getLong(4), rs.getLong(5), rs.getBytes(6));
+				return new BoxExternalFile(new QblECPublicKey(rs.getBytes(1)), rs.getString(2), rs.getString(3),
+						rs.getString(4), rs.getLong(5), rs.getLong(6), rs.getBytes(7));
 			}
 			return null;
 		} catch (SQLException e) {


### PR DESCRIPTION
Shared BoxFiles could not be downloaded, because the different handling of a url with or without the prefix. To always handle BoxFiles the same way, no matter if they are the own files or a received one, BoxFiles now have a prefix and block member.

The SQLite databases also has to be changed to include this member, a PR for the documentation will follow.

Since the SQLite databases has changed and I don't provide an update method, this will break current installations and their file system.
