### PR TITLE
Fixed BoxFile meta and metakey entries was not updated in DirectoryMetadata

### DIFF
--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/BoxTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/storage/BoxTest.java
@@ -292,6 +292,15 @@ public class BoxTest extends AndroidTestCase {
 		nav.commit();
 
 		assertThat(boxFile.isShared(), is(false));
+
+		// Check that BoxFile.meta and BoxFile.metakey is actually removed
+		// from DirectoryMetadata and thus null in reloaded BoxFile.
+		nav = volume.navigate();
+		BoxFile receivedBoxFile = nav.listFiles().get(0);
+
+		assertThat(boxFile, equalTo(receivedBoxFile));
+		assertThat(false, is(boxFile.isShared()));
+
 	}
 
 	@Test

--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/AbstractNavigation.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/AbstractNavigation.java
@@ -446,6 +446,17 @@ public abstract class AbstractNavigation implements BoxNavigation {
 		boxFile.meta = null;
 		boxFile.metakey = null;
 
+		try {
+			// Overwrite = delete old file, upload new file
+			BoxFile oldFile = dm.getFile(boxFile.name);
+			if (oldFile != null) {
+				dm.deleteFile(oldFile);
+			}
+			dm.insertFile(boxFile);
+			reloadMetadata();
+		} catch (QblStorageException e) {
+			Log.e(TAG,"error until reload metadata",e);
+		}
 		return true;
 	}
 


### PR DESCRIPTION
* Removed BoxFile.meta and BoxFile.metakey were not removed from the
DirectoryMetadata, only from the BoxFile in the parameter. If the
BoxFile was reloaded from the server new BoxFiles are created instead of
reusing existing files. Thus meta and metakey were still existing and
thus BoxFile was still shown as shared.
* Expanded the test to trigger this bug

Resolves #274