### PR TITLE
Removed suicide button

### DIFF
--- a/qabelbox/src/main/java/de/qabel/qabelbox/fragments/SettingsFragment.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/fragments/SettingsFragment.java
@@ -45,22 +45,6 @@ public class SettingsFragment extends PreferenceFragment {
                 return true;
             }
         });
-		findPreference(getString(R.string.settings_key_internal_reset_app_data)).setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
-			@Override
-			public boolean onPreferenceClick(Preference preference) {
-				clearAllAppData(getActivity());
-				return true;
-			}
-		});
-
     }
-	public static void clearAllAppData(Context context) {
-		if (Build.VERSION_CODES.KITKAT <= Build.VERSION.SDK_INT) {
-			boolean ret=	((ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE))
-					.clearApplicationUserData(); // note: it has a return value!
-		} else {
-			// once minSdkVersion goes above 19 in a few years.
-		}
-	}
 }
 

--- a/qabelbox/src/main/res/values-de/strings.xml
+++ b/qabelbox/src/main/res/values-de/strings.xml
@@ -153,8 +153,6 @@
     <string name="uploading">hochladen</string>
     <string name="uploading_file">Datei </string>
     <string name="yes">Ja</string>
-    <string name="clear_app_data">App-Daten löschen</string>
-    <string name="clear_app_data_summary">Löscht alle App-Daten ohne eine Warnung</string>
     <string name="function_not_yet_implenented">Funktion ist noch nicht implementiert</string>
     <string name="refresh">Aktualisieren</string>
     <string name="btn_chat_send">Senden</string>

--- a/qabelbox/src/main/res/values/strings.xml
+++ b/qabelbox/src/main/res/values/strings.xml
@@ -194,11 +194,8 @@
     <string name="message_unshare_not_successfull">Can\'t revoke share</string>
     <string name="message_unshare_successfull">Share successfully revoked</string>
     <string name="message_revoke_share">Revoking share</string>
-    <string name="settings_key_internal_reset_app_data" translatable="false">key_debug_reset_app_data</string>
     <string name="message_chat_message_not_sended">Message NOT sended</string>
     <string name="create_idenity_cant_get_prefix">Could not retrieve a prefix from the server</string>
-    <string name="clear_app_data">Clear app data</string>
-    <string name="clear_app_data_summary">Clean all data without warning</string>
     <plurals name="uploadsNotificationTitle">
         <item quantity="one">Uploading</item>
         <item quantity="other">Uploads remaining: %d</item>

--- a/qabelbox/src/main/res/xml/app_settings.xml
+++ b/qabelbox/src/main/res/xml/app_settings.xml
@@ -5,11 +5,6 @@
             android:key="@string/settings_key_internal_feedback"
             android:summary="@string/debug_send_feedback_to_pm"
             android:title="@string/debug_send_feedback" />
-        <Preference
-            android:key="@string/settings_key_internal_reset_app_data"
-            android:summary="@string/clear_app_data_summary"
-            android:title="@string/clear_app_data" />
-
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/general_settings">
         <CheckBoxPreference


### PR DESCRIPTION
I don't think we want or need a suicide button in the app that deletes all data without a further confirmation. (Even with confirmation this would probably unnecessary because Android provides this functionally).