### PR TITLE
Use index dm name calculation from key class directly

### DIFF
--- a/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxVolume.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/storage/BoxVolume.java
@@ -124,21 +124,8 @@ public class BoxVolume {
         return DirectoryMetadata.openDatabase(tmp, deviceId, rootRef, tempDir);
     }
 
-    public String getRootRef() throws QblStorageException {
-
-        MessageDigest md;
-        try {
-            md = MessageDigest.getInstance("SHA-256");
-        } catch (NoSuchAlgorithmException e) {
-            throw new QblStorageException(e);
-        }
-        md.update(this.prefix.getBytes());
-        md.update(keyPair.getPrivateKey());
-        byte[] digest = md.digest();
-        byte[] firstBytes = Arrays.copyOfRange(digest, 0, 16);
-        ByteBuffer bb = ByteBuffer.wrap(firstBytes);
-        UUID uuid = new UUID(bb.getLong(), bb.getLong());
-        return uuid.toString();
+    public String getRootRef() {
+        return keyPair.getRootRef(this.prefix);
     }
 
     public void createIndex() throws QblStorageException {


### PR DESCRIPTION
Moved index DM name calculation to reduce need of private key outside of the key pair class (see https://github.com/Qabel/qabel-core/issues/442)
**Important: Only merge after https://github.com/Qabel/qabel-core/pull/467 is merged!**