### PR TITLE
fix locale 

### DIFF
--- a/qabelbox/src/main/java/de/qabel/qabelbox/communication/BaseServer.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/communication/BaseServer.java
@@ -44,7 +44,7 @@ public class BaseServer {
     protected void addHeader(String token, Request.Builder builder) {
 
         String locale = Locale.getDefault().getLanguage();
-        builder.addHeader("Accept-Language", locale);
+        builder.addHeader("accept-language", locale);
         builder.addHeader("Accept", "application/json");
         if (token != null) {
             builder.addHeader("Authorization", "Token " + token);


### PR DESCRIPTION
for account and other server communication. with this fix, the app show localizated account response messages like 'passwort zu kurz'.