### PR TITLE
changed downloadicon to qabel logo

### DIFF
--- a/qabelbox/src/main/java/de/qabel/qabelbox/providers/BoxProvider.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/providers/BoxProvider.java
@@ -632,7 +632,7 @@ public class BoxProvider extends DocumentsProvider {
         }
         mBuilder.setContentTitle("Downloading " + filename)
                 .setContentText("Download complete")
-                .setSmallIcon(R.drawable.notification_template_icon_bg);
+                .setSmallIcon(R.drawable.qabel_logo);
         mBuilder.setProgress(100, 100, false);
         mNotifyManager.notify(id, mBuilder.build());
         File out = new File(getContext().getExternalCacheDir(), basename);

--- a/qabelbox/src/main/java/de/qabel/qabelbox/providers/BoxProvider.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/providers/BoxProvider.java
@@ -599,7 +599,7 @@ public class BoxProvider extends DocumentsProvider {
         final NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(getContext());
         mBuilder.setContentTitle("Downloading " + mDocumentIdParser.getBaseName(documentId))
                 .setContentText("Download in progress")
-                .setSmallIcon(R.drawable.notification_template_icon_bg);
+                .setSmallIcon(R.drawable.qabel_logo);
         mBuilder.setProgress(100, 0, false);
         mNotifyManager.notify(id, mBuilder.build());
 


### PR DESCRIPTION
fixes #378

Added qabel logo because there is no download icon available.
We need more icons and organize them!