### PR TITLE
Add handling for storage exception on init volume and navigation

### DIFF
--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/ui/ImportExportContactsUITest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/ui/ImportExportContactsUITest.java
@@ -57,10 +57,9 @@ public class ImportExportContactsUITest extends AbstractUITest {
 
         createTestContacts();
 
-        Intent intent = new Intent(Intent.ACTION_MAIN);
-        intent.putExtra(MainActivity.START_CONTACTS_FRAGMENT, true);
+        Intent intent = new Intent(mContext, MainActivity.class);
         intent.putExtra(MainActivity.START_FILES_FRAGMENT, false);
-        intent.putExtra(MainActivity.ACTIVE_IDENTITY, identity.getKeyIdentifier());
+        intent.putExtra(MainActivity.START_CONTACTS_FRAGMENT, true);
         launchActivity(intent);
     }
 

--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/ui/files/FilesFragmentUIInitTest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/ui/files/FilesFragmentUIInitTest.java
@@ -1,0 +1,61 @@
+package de.qabel.qabelbox.ui.files;
+
+import android.content.Intent;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+
+import de.qabel.core.config.Identity;
+import de.qabel.qabelbox.activities.MainActivity;
+import de.qabel.qabelbox.storage.BoxVolume;
+
+import static junit.framework.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+
+public class FilesFragmentUIInitTest extends FilesFragmentUITestBase {
+
+    private Identity testIdentity2;
+
+    @Before
+    public void setUp() throws Throwable {
+        this.autoLaunch = false;
+        super.setUp();
+    }
+
+    private void launchActivity(String identity) {
+        Intent intent = new Intent(mContext, MainActivity.class);
+        intent.putExtra(MainActivity.ACTIVE_IDENTITY, identity);
+        launchActivity(intent);
+        mActivity.filesFragment.injectIdleCallback(getIdlingResource());
+    }
+
+    @Override
+    protected void setupData() throws Exception {
+        testIdentity2 = mBoxHelper.addIdentityWithoutVolume("spoon2");
+        mBoxHelper.setActiveIdentity(testIdentity2);
+    }
+
+    @Test
+    public void testCreateInitialVolume() throws Exception {
+        launchActivity(testIdentity2.getKeyIdentifier());
+        assertNotNull("Navigation not initialized!", mActivity.filesFragment.getBoxNavigation());
+    }
+
+    @Test
+    public void testVolumeNotAvailable() throws Exception {
+        //Corrupt volume root file
+        BoxVolume volume = mBoxHelper.getIdentityVolume(identity);
+        byte[] random = RandomUtils.nextBytes(1000);
+        mBoxHelper.getBoxManager().blockingUpload(identity.getPrefixes().get(0),
+                volume.getRootRef(), new ByteArrayInputStream(random));
+
+        //Start with corrupted volume
+        launchActivity(identity.getKeyIdentifier());
+        //if a navigation is created, the existing volume has been overridden.
+        assertNull("Navigation initialized, overriding volume", mActivity.filesFragment.getBoxNavigation());
+    }
+
+}

--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/ui/files/FilesFragmentUITest.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/ui/files/FilesFragmentUITest.java
@@ -83,8 +83,7 @@ public class FilesFragmentUITest extends FilesFragmentUITestBase {
     @Override
     public void cleanUp() {
         try {
-            mBoxHelper.deleteIdentity(testIdentity);
-            mBoxHelper.deleteIdentity(testIdentity2);
+            mBoxHelper.removeAllIdentities();
         } catch (Exception e) {
             //TODO Bad
         }

--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/ui/files/FilesFragmentUITestBase.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/ui/files/FilesFragmentUITestBase.java
@@ -12,6 +12,7 @@ import de.qabel.qabelbox.ui.idling.InjectedIdlingResource;
 
 public abstract class FilesFragmentUITestBase extends AbstractUITest {
 
+    protected boolean autoLaunch = true;
     private InjectedIdlingResource idlingResource;
 
     protected class ExampleFile {
@@ -42,9 +43,12 @@ public abstract class FilesFragmentUITestBase extends AbstractUITest {
     public void setUp() throws Throwable {
         super.setUp();
         setupData();
-        Intent intent = new Intent(mContext, MainActivity.class);
-        intent.putExtra(MainActivity.ACTIVE_IDENTITY, identity.getKeyIdentifier());
-        launchActivity(intent);
+        if(autoLaunch) {
+            Intent intent = new Intent(mContext, MainActivity.class);
+            intent.putExtra(MainActivity.ACTIVE_IDENTITY, mBoxHelper.
+                    getCurrentIdentity().getKeyIdentifier());
+            launchActivity(intent);
+        }
         idlingResource = new InjectedIdlingResource();
         Espresso.registerIdlingResources(idlingResource);
     }

--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/ui/helper/UIBoxHelper.java
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/ui/helper/UIBoxHelper.java
@@ -280,4 +280,8 @@ public class UIBoxHelper {
     public ContactRepository getContactRepository() {
         return contactRepository;
     }
+
+    public BoxManager getBoxManager(){
+        return this.boxManager;
+    }
  }

--- a/qabelbox/src/main/java/de/qabel/qabelbox/config/AppPreference.java
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/config/AppPreference.java
@@ -86,7 +86,7 @@ public class AppPreference {
                 byte[] deviceIDBytes = cryptoUtils.getRandomBytes(NUM_BYTES_DEVICE_ID);
                 deviceID = Hex.toHexString(deviceIDBytes);
             }
-            settings.edit().putString(P_DEVICE_ID, deviceID);
+            settings.edit().putString(P_DEVICE_ID, deviceID).commit();
         }
         return Hex.decode(deviceID);
     }
@@ -101,7 +101,7 @@ public class AppPreference {
     }
 
     public void setLastActiveIdentityKey(String identityKey) {
-        settings.edit().putString(P_LAST_ACTIVE_IDENTITY, identityKey);
+        settings.edit().putString(P_LAST_ACTIVE_IDENTITY, identityKey).commit();
     }
 
 }


### PR DESCRIPTION
resolves #534

A new volume should be initialized only when we get a StorageNotFoundException.