### PR TITLE
Revert "maxSdk"

### DIFF
--- a/qabelbox/build.gradle
+++ b/qabelbox/build.gradle
@@ -39,7 +39,6 @@ android {
         buildConfigField "long", "TIMESTAMP", System.currentTimeMillis() + "L"
         applicationId "de.qabel.qabel"
         minSdkVersion 19
-        maxSdkVersion 23
         targetSdkVersion 23
         multiDexEnabled true
         /*


### PR DESCRIPTION
Reverts Qabel/qabel-android#729

Setting maxSdkVersion is not really supported anymore in the play store.