### PR TITLE
Use custom jdbc prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+* Android 7 compatibility

--- a/qabelbox/build.gradle
+++ b/qabelbox/build.gradle
@@ -170,7 +170,7 @@ tasks.withType(Test) {
     systemProperty 'java.library.path', 'libs/'
 }
 
-def coreVersion = '0.25.4'
+def coreVersion = '0.25.7'
 def repo = 'Qabel'
 dependencies {
     sourceCompatibility = JavaVersion.VERSION_1_7

--- a/qabelbox/src/androidTest/java/de/qabel/qabelbox/box/AndroidBoxVolumeTest.kt
+++ b/qabelbox/src/androidTest/java/de/qabel/qabelbox/box/AndroidBoxVolumeTest.kt
@@ -7,7 +7,7 @@ import de.qabel.box.storage.jdbc.JdbcDirectoryMetadataFactory
 import de.qabel.box.storage.jdbc.JdbcFileMetadataFactory
 import de.qabel.core.repositories.AndroidVersionAdapter
 import de.qabel.qabelbox.box.backends.MockStorageBackend
-import de.qabel.qabelbox.box.interactor.jdbcPrefix
+import de.qabel.qabelbox.box.interactor.JdbcPrefix
 import de.qabel.qabelbox.util.IdentityHelper
 import org.junit.Before
 import org.junit.Test
@@ -41,7 +41,7 @@ class AndroidBoxVolumeTest {
                 directoryMetadataFactoryFactory = { tempDir, deviceId ->
                     JdbcDirectoryMetadataFactory(tempDir, deviceId, { connection ->
                         DirectoryMetadataDatabase(connection, AndroidVersionAdapter(connection))
-                    }, jdbcPrefix = jdbcPrefix)
+                    }, jdbcPrefix = JdbcPrefix.jdbcPrefix)
                 },
                 fileMetadataFactoryFactory = { tempDir ->
                     JdbcFileMetadataFactory(tempDir, versionAdapterFactory = { connection ->
@@ -56,7 +56,7 @@ class AndroidBoxVolumeTest {
     @Test
     fun testMigrationRespectsDatabaseVersion() {
         val connection = DriverManager.getConnection(
-                jdbcPrefix + createTempFile().absolutePath)
+                JdbcPrefix.jdbcPrefix + createTempFile().absolutePath)
         connection.autoCommit = true
         val db = DirectoryMetadataDatabase(connection,
                 versionAdapter = AndroidVersionAdapter(connection))

--- a/qabelbox/src/main/java/de/qabel/qabelbox/box/interactor/factories.kt
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/box/interactor/factories.kt
@@ -15,7 +15,9 @@ import de.qabel.qabelbox.storage.server.BlockServer
 import java.io.File
 import java.sql.Connection
 
-val jdbcPrefix = "jdbc:sqldroid:"
+object JdbcPrefix {
+    var jdbcPrefix = "jdbc:sqldroid:"
+}
 
 fun makeFileBrowserFactory(identityRepository: IdentityRepository,
                            contactRepository: ContactRepository,
@@ -40,12 +42,12 @@ fun makeFileBrowserFactory(identityRepository: IdentityRepository,
                 tempDir,
                 directoryMetadataFactoryFactory = { tempDir, deviceId ->
                     JdbcDirectoryMetadataFactory(tempDir, deviceId, dataBaseFactory,
-                            jdbcPrefix = jdbcPrefix)
+                            jdbcPrefix = JdbcPrefix.jdbcPrefix)
                 },
                 fileMetadataFactoryFactory = { tempDir ->
                     JdbcFileMetadataFactory(tempDir, versionAdapterFactory = { connection ->
                         AndroidVersionAdapter(connection)},
-                            jdbcPrefix = jdbcPrefix)
+                            jdbcPrefix = JdbcPrefix.jdbcPrefix)
                 }),
                 identity.primaryKeyPair)
         return BoxFileBrowser(BoxFileBrowser.KeyAndPrefix(key, identity.prefixes.first()), volume, contactRepository)

--- a/qabelbox/src/main/java/de/qabel/qabelbox/box/interactor/factories.kt
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/box/interactor/factories.kt
@@ -15,6 +15,8 @@ import de.qabel.qabelbox.storage.server.BlockServer
 import java.io.File
 import java.sql.Connection
 
+val jdbcPrefix = "jdbc:sqldroid:"
+
 fun makeFileBrowserFactory(identityRepository: IdentityRepository,
                            contactRepository: ContactRepository,
                            deviceId: ByteArray,
@@ -37,11 +39,13 @@ fun makeFileBrowserFactory(identityRepository: IdentityRepository,
                 "Blake2b",
                 tempDir,
                 directoryMetadataFactoryFactory = { tempDir, deviceId ->
-                    JdbcDirectoryMetadataFactory(tempDir, deviceId, dataBaseFactory)
+                    JdbcDirectoryMetadataFactory(tempDir, deviceId, dataBaseFactory,
+                            jdbcPrefix = jdbcPrefix)
                 },
                 fileMetadataFactoryFactory = { tempDir ->
                     JdbcFileMetadataFactory(tempDir, versionAdapterFactory = { connection ->
-                        AndroidVersionAdapter(connection)})
+                        AndroidVersionAdapter(connection)},
+                            jdbcPrefix = jdbcPrefix)
                 }),
                 identity.primaryKeyPair)
         return BoxFileBrowser(BoxFileBrowser.KeyAndPrefix(key, identity.prefixes.first()), volume, contactRepository)

--- a/qabelbox/src/main/java/de/qabel/qabelbox/box/interactor/factories.kt
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/box/interactor/factories.kt
@@ -16,6 +16,7 @@ import java.io.File
 import java.sql.Connection
 
 object JdbcPrefix {
+    @JvmField
     var jdbcPrefix = "jdbc:sqldroid:"
 }
 

--- a/qabelbox/src/main/java/de/qabel/qabelbox/dagger/modules/FileBrowserModule.kt
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/dagger/modules/FileBrowserModule.kt
@@ -106,11 +106,13 @@ class FileBrowserModule(private val view: FileBrowserView) {
                 "Blake2b",
                 tempDir,
                 directoryMetadataFactoryFactory = { tempDir, deviceId ->
-                    JdbcDirectoryMetadataFactory(tempDir, deviceId, dataBaseFactory)
+                    JdbcDirectoryMetadataFactory(tempDir, deviceId, dataBaseFactory,
+                            jdbcPrefix = jdbcPrefix)
                 },
                 fileMetadataFactoryFactory = { tempDir ->
                     JdbcFileMetadataFactory(tempDir, versionAdapterFactory = { connection ->
-                        AndroidVersionAdapter(connection)})
+                        AndroidVersionAdapter(connection)},
+                            jdbcPrefix = jdbcPrefix)
                 }),
                 identity.primaryKeyPair)
 

--- a/qabelbox/src/main/java/de/qabel/qabelbox/dagger/modules/FileBrowserModule.kt
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/dagger/modules/FileBrowserModule.kt
@@ -107,12 +107,12 @@ class FileBrowserModule(private val view: FileBrowserView) {
                 tempDir,
                 directoryMetadataFactoryFactory = { tempDir, deviceId ->
                     JdbcDirectoryMetadataFactory(tempDir, deviceId, dataBaseFactory,
-                            jdbcPrefix = jdbcPrefix)
+                            jdbcPrefix = JdbcPrefix.jdbcPrefix)
                 },
                 fileMetadataFactoryFactory = { tempDir ->
                     JdbcFileMetadataFactory(tempDir, versionAdapterFactory = { connection ->
                         AndroidVersionAdapter(connection)},
-                            jdbcPrefix = jdbcPrefix)
+                            jdbcPrefix = JdbcPrefix.jdbcPrefix)
                 }),
                 identity.primaryKeyPair)
 

--- a/qabelbox/src/main/java/de/qabel/qabelbox/persistence/RepositoryFactory.kt
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/persistence/RepositoryFactory.kt
@@ -16,6 +16,7 @@ import de.qabel.core.repository.sqlite.hydrator.IdentityHydrator
 import de.qabel.qabelbox.exceptions.QblPersistenceException
 import java.io.File
 import java.sql.Connection
+import java.sql.Driver
 import java.sql.DriverManager
 import java.sql.SQLException
 
@@ -38,7 +39,8 @@ class RepositoryFactory(private val context: Context) {
 
     private fun loadDriver() {
         try {
-            Class.forName("org.sqldroid.SQLDroidDriver")
+            DriverManager.registerDriver(
+                    Class.forName("org.sqldroid.SQLDroidDriver").newInstance() as Driver)
         } catch (e: ClassNotFoundException) {
             throw RuntimeException(e)
         }
@@ -63,7 +65,7 @@ class RepositoryFactory(private val context: Context) {
     fun getAndroidClientDatabase(): AndroidClientDatabase {
         val conn = connection ?:
                 try {
-                    val c = DriverManager.getConnection("jdbc:sqlite:" + databasePath)
+                    val c = DriverManager.getConnection("jdbc:sqldroid:" + databasePath)
                     connection = c
                     c
                 } catch (e: SQLException) {

--- a/qabelbox/src/main/java/de/qabel/qabelbox/persistence/RepositoryFactory.kt
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/persistence/RepositoryFactory.kt
@@ -6,13 +6,12 @@ import de.qabel.chat.repository.ChatDropMessageRepository
 import de.qabel.chat.repository.ChatShareRepository
 import de.qabel.chat.repository.sqlite.SqliteChatDropMessageRepository
 import de.qabel.chat.repository.sqlite.SqliteChatShareRepository
-import de.qabel.core.config.factory.DefaultIdentityFactory
 import de.qabel.core.repositories.AndroidClientDatabase
 import de.qabel.core.repositories.AndroidFakeEntityManager
 import de.qabel.core.repository.*
 import de.qabel.core.repository.sqlite.*
 import de.qabel.core.repository.sqlite.hydrator.DropURLHydrator
-import de.qabel.core.repository.sqlite.hydrator.IdentityHydrator
+import de.qabel.qabelbox.box.interactor.JdbcPrefix
 import de.qabel.qabelbox.exceptions.QblPersistenceException
 import java.io.File
 import java.sql.Connection
@@ -65,7 +64,7 @@ class RepositoryFactory(private val context: Context) {
     fun getAndroidClientDatabase(): AndroidClientDatabase {
         val conn = connection ?:
                 try {
-                    val c = DriverManager.getConnection("jdbc:sqldroid:" + databasePath)
+                    val c = DriverManager.getConnection(JdbcPrefix.jdbcPrefix + databasePath)
                     connection = c
                     c
                 } catch (e: SQLException) {

--- a/qabelbox/src/test/java/de/qabel/qabelbox/RoboApplication.java
+++ b/qabelbox/src/test/java/de/qabel/qabelbox/RoboApplication.java
@@ -19,7 +19,7 @@ public class RoboApplication extends TestApplication {
         new AppPreference(this).setToken(TestConstants.TOKEN);
         super.onCreate();
         ShadowLog.stream = System.out;
-        JdbcPrefix.INSTANCE.setJdbcPrefix("jdbc:sqlite:");
+        JdbcPrefix.jdbcPrefix = "jdbc:sqlite:";
     }
 
     @Override

--- a/qabelbox/src/test/java/de/qabel/qabelbox/RoboApplication.java
+++ b/qabelbox/src/test/java/de/qabel/qabelbox/RoboApplication.java
@@ -5,6 +5,7 @@ import android.content.ServiceConnection;
 
 import org.robolectric.shadows.ShadowLog;
 
+import de.qabel.qabelbox.box.interactor.JdbcPrefix;
 import de.qabel.qabelbox.communication.URLs;
 import de.qabel.qabelbox.config.AppPreference;
 import de.qabel.qabelbox.test.TestConstants;
@@ -18,6 +19,7 @@ public class RoboApplication extends TestApplication {
         new AppPreference(this).setToken(TestConstants.TOKEN);
         super.onCreate();
         ShadowLog.stream = System.out;
+        JdbcPrefix.INSTANCE.setJdbcPrefix("jdbc:sqlite:");
     }
 
     @Override


### PR DESCRIPTION
This prevents the native jdbc driver from being loaded, which crashes on android 7.

Resolves #713