### PR TITLE
Fix Sharing on Android 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.0.4'
+    ext.kotlin_version = '1.0.5'
     ext.anko_version = '0.9'
     ext.core_version = '0.7.0'
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.stanfy.spoon:spoon-gradle-plugin:1.0.4'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/qabelbox/src/main/java/de/qabel/qabelbox/box/interactor/factories.kt
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/box/interactor/factories.kt
@@ -2,6 +2,7 @@ package de.qabel.qabelbox.box.interactor
 
 import de.qabel.box.storage.AndroidBoxVolume
 import de.qabel.box.storage.BoxVolumeConfig
+import de.qabel.box.storage.FileMetadataFactory
 import de.qabel.box.storage.RootRefCalculator
 import de.qabel.box.storage.exceptions.QblStorageException
 import de.qabel.box.storage.jdbc.DirectoryMetadataDatabase
@@ -27,7 +28,8 @@ private fun keysAndVolume(volumeRoot: VolumeRoot,
                           identityRepository: IdentityRepository,
                           deviceId: ByteArray,
                           tempDir: File,
-                          androidBlockServer: BlockServer): Pair<BoxReadFileBrowser.KeyAndPrefix, VolumeNavigator> {
+                          androidBlockServer: BlockServer,
+                          fileMetadataFactory: FileMetadataFactory): Pair<BoxReadFileBrowser.KeyAndPrefix, VolumeNavigator> {
     val docId = volumeRoot.documentID.toDocumentId()
     val key = docId.identityKey
     val identity = identityRepository.find(key)
@@ -68,16 +70,19 @@ fun makeFileBrowserFactory(identityRepository: IdentityRepository,
                            contactRepository: ContactRepository,
                            deviceId: ByteArray,
                            tempDir: File,
-                           androidBlockServer: BlockServer, scheduler: BoxScheduler):
+                           androidBlockServer: BlockServer, scheduler: BoxScheduler,
+                           fileMetadataFactory: FileMetadataFactory):
         Pair<(VolumeRoot) -> ReadFileBrowser, (VolumeRoot) -> OperationFileBrowser> {
 
     return Pair(
             fun(volumeRoot: VolumeRoot): ReadFileBrowser {
-                val (keyAndPrefix, volumeNavigator) = keysAndVolume(volumeRoot, identityRepository, deviceId, tempDir, androidBlockServer)
+                val (keyAndPrefix, volumeNavigator) = keysAndVolume(volumeRoot, identityRepository,
+                        deviceId, tempDir, androidBlockServer, fileMetadataFactory)
                 return BoxReadFileBrowser(keyAndPrefix, volumeNavigator, contactRepository, scheduler)
             },
             fun(volumeRoot: VolumeRoot): OperationFileBrowser {
-                val (keyAndPrefix, volumeNavigator) = keysAndVolume(volumeRoot, identityRepository, deviceId, tempDir, androidBlockServer)
+                val (keyAndPrefix, volumeNavigator) = keysAndVolume(volumeRoot, identityRepository,
+                        deviceId, tempDir, androidBlockServer, fileMetadataFactory)
                 return BoxOperationFileBrowser(keyAndPrefix, volumeNavigator, contactRepository, scheduler)
             })
 }

--- a/qabelbox/src/main/java/de/qabel/qabelbox/dagger/modules/StorageModule.kt
+++ b/qabelbox/src/main/java/de/qabel/qabelbox/dagger/modules/StorageModule.kt
@@ -66,7 +66,7 @@ open class StorageModule {
     @Singleton
     @Provides
     internal fun provideFileMetadataFactory(cacheDir: File): FileMetadataFactory {
-        return JdbcFileMetadataFactory(cacheDir, { connection -> AndroidVersionAdapter(connection) })
+        return JdbcFileMetadataFactory(cacheDir, ::AndroidVersionAdapter, JdbcPrefix.jdbcPrefix)
     }
 
     @Singleton
@@ -101,10 +101,12 @@ open class StorageModule {
                              contactRepository: ContactRepository,
                              preference: AppPreference,
                              context: Context, blockServer: BlockServer,
-                             scheduler: BoxScheduler):
+                             scheduler: BoxScheduler,
+                             fileMetadataFactory: FileMetadataFactory):
             VolumeManager {
         val (read, operation) = makeFileBrowserFactory(
-                identityRepository, contactRepository, preference.deviceId, context.cacheDir, blockServer, scheduler)
+                identityRepository, contactRepository, preference.deviceId,
+                context.cacheDir, blockServer, scheduler, fileMetadataFactory)
         return BoxVolumeManager(identityRepository, read, operation)
     }
 


### PR DESCRIPTION
The jdbc prefix was not set for the filemetadata factory of
the sharing service. Now there is only of of those
factories, which uses the correct prefix.

Also, gradle is updated to 2.2.3 and Kotlin to 1.0.5.